### PR TITLE
feat: add fan-out agent pattern for parallel chunk processing

### DIFF
--- a/.llm-orc/ensembles/fan-out-test.yaml
+++ b/.llm-orc/ensembles/fan-out-test.yaml
@@ -1,0 +1,15 @@
+name: fan-out-test
+description: Test ensemble demonstrating fan-out agent pattern (issue #73)
+
+agents:
+  - name: chunker
+    type: script
+    script: scripts/fan-out-test/chunker.py
+    system_prompt: Split input text into sentences
+
+  - name: processor
+    type: script
+    script: scripts/fan-out-test/processor.py
+    depends_on: [chunker]
+    fan_out: true
+    system_prompt: Analyze each sentence chunk

--- a/.llm-orc/scripts/fan-out-test/chunker.py
+++ b/.llm-orc/scripts/fan-out-test/chunker.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Chunker script that splits input text into sentences for fan-out processing."""
+
+import json
+import re
+import sys
+
+
+def chunk_text(text: str) -> list[str]:
+    """Split text into sentences."""
+    # Simple sentence splitting on . ! ?
+    sentences = re.split(r'(?<=[.!?])\s+', text.strip())
+    # Filter out empty sentences
+    return [s.strip() for s in sentences if s.strip()]
+
+
+def main() -> None:
+    """Read input and output chunks as JSON array."""
+    try:
+        # Read input from stdin (JSON format)
+        input_data = json.load(sys.stdin)
+        text = input_data.get("input", "")
+
+        if not text:
+            result = {
+                "success": False,
+                "error": "No input text provided",
+                "data": []
+            }
+        else:
+            chunks = chunk_text(text)
+            result = {
+                "success": True,
+                "data": chunks  # This array will trigger fan-out
+            }
+    except json.JSONDecodeError:
+        result = {
+            "success": False,
+            "error": "Invalid JSON input",
+            "data": []
+        }
+    except Exception as e:
+        result = {
+            "success": False,
+            "error": str(e),
+            "data": []
+        }
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/.llm-orc/scripts/fan-out-test/processor.py
+++ b/.llm-orc/scripts/fan-out-test/processor.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Processor script that analyzes a single chunk (fan-out instance)."""
+
+import json
+import sys
+
+
+def analyze_chunk(chunk: str, index: int, total: int) -> dict:
+    """Analyze a single chunk of text."""
+    return {
+        "chunk_index": index,
+        "total_chunks": total,
+        "original_text": chunk,
+        "word_count": len(chunk.split()),
+        "char_count": len(chunk),
+        "has_question": "?" in chunk,
+        "has_exclamation": "!" in chunk,
+    }
+
+
+def main() -> None:
+    """Read chunk input and output analysis."""
+    try:
+        # Read input from stdin (JSON format with chunk metadata)
+        input_data = json.load(sys.stdin)
+
+        # Fan-out provides: input (the chunk), chunk_index, total_chunks, base_input
+        chunk = input_data.get("input", "")
+        chunk_index = input_data.get("chunk_index", 0)
+        total_chunks = input_data.get("total_chunks", 1)
+
+        if not chunk:
+            result = {
+                "success": False,
+                "error": "No chunk provided",
+                "data": None
+            }
+        else:
+            analysis = analyze_chunk(chunk, chunk_index, total_chunks)
+            result = {
+                "success": True,
+                "data": analysis
+            }
+    except json.JSONDecodeError:
+        result = {
+            "success": False,
+            "error": "Invalid JSON input",
+            "data": None
+        }
+    except Exception as e:
+        result = {
+            "success": False,
+            "error": str(e),
+            "data": None
+        }
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/llm_orc/cli_modules/utils/visualization/results_display.py
+++ b/src/llm_orc/cli_modules/utils/visualization/results_display.py
@@ -60,6 +60,11 @@ def display_results(
             )
 
             response = results[final_agent]["response"]
+            # Handle list responses (e.g., fan-out gathered results)
+            if isinstance(response, list):
+                import json
+
+                response = json.dumps(response, indent=2)
             # Use direct stdout to prevent truncation
             import sys
 
@@ -156,10 +161,16 @@ def _display_agent_result(
             f"{model_display}{timing_display}[/dim]"
         )
         if response:
+            # Handle list responses (e.g., fan-out gathered results)
+            display_response = response
+            if isinstance(display_response, list):
+                import json
+
+                display_response = json.dumps(display_response, indent=2)
             # Use direct stdout approach to bypass all Rich limitations
             import sys
 
-            sys.stdout.write(response)
+            sys.stdout.write(display_response)
             sys.stdout.write("\n\n")
             sys.stdout.flush()
         else:
@@ -571,10 +582,16 @@ def _get_agent_model_info(
     return ""
 
 
-def _has_code_content(text: str) -> bool:
+def _has_code_content(text: str | list[Any]) -> bool:
     """Check if text contains code-like content."""
     if not text:
         return False
+
+    # Handle list responses (e.g., fan-out gathered results)
+    if isinstance(text, list):
+        import json
+
+        text = json.dumps(text)
 
     code_indicators = ["def ", "class ", "```", "import ", "function", "{", "}", ";"]
     return any(indicator in text.lower() for indicator in code_indicators)

--- a/src/llm_orc/core/config/ensemble_config.py
+++ b/src/llm_orc/core/config/ensemble_config.py
@@ -86,6 +86,25 @@ def _check_agents_for_cycles(agents: list[dict[str, Any]]) -> None:
                 )
 
 
+def _validate_fan_out_dependencies(agents: list[dict[str, Any]]) -> None:
+    """Validate that fan_out agents have required dependencies.
+
+    Args:
+        agents: List of agent configurations
+
+    Raises:
+        ValueError: If any agent has fan_out: true without depends_on
+    """
+    for agent in agents:
+        if agent.get("fan_out") is True:
+            depends_on = agent.get("depends_on", [])
+            if not depends_on:
+                raise ValueError(
+                    f"Agent '{agent['name']}' has fan_out: true but requires "
+                    f"depends_on to specify the upstream agent providing the array"
+                )
+
+
 def _check_missing_dependencies(agents: list[dict[str, Any]]) -> None:
     """Check for missing dependencies in agent configurations.
 
@@ -211,6 +230,9 @@ class EnsembleLoader:
         """Validate agent dependencies for cycles and missing dependencies."""
         # Check for missing dependencies first
         _check_missing_dependencies(agents)
+
+        # Validate fan_out agents have dependencies
+        _validate_fan_out_dependencies(agents)
 
         # Then check for circular dependencies
         _detect_circular_dependencies(agents)

--- a/src/llm_orc/core/execution/dependency_analyzer.py
+++ b/src/llm_orc/core/execution/dependency_analyzer.py
@@ -1,5 +1,6 @@
 """Agent dependency analysis for execution planning."""
 
+import re
 from typing import Any
 
 
@@ -178,3 +179,35 @@ class DependencyAnalyzer:
             errors.append(str(e))
 
         return errors
+
+    # ========== Fan-Out Support (Issue #73) ==========
+
+    # Pattern for instance names: agent_name[index]
+    _INSTANCE_PATTERN = re.compile(r"^(.+)\[(\d+)\]$")
+
+    def normalize_agent_name(self, name: str) -> str:
+        """Normalize agent name by removing instance index if present.
+
+        Converts 'extractor[0]' to 'extractor' for dependency checking.
+
+        Args:
+            name: Agent name, possibly with instance index
+
+        Returns:
+            Original agent name without index
+        """
+        match = self._INSTANCE_PATTERN.match(name)
+        if match:
+            return match.group(1)
+        return name
+
+    def is_fan_out_instance_name(self, name: str) -> bool:
+        """Check if name matches the fan-out instance pattern 'agent[N]'.
+
+        Args:
+            name: Agent name to check
+
+        Returns:
+            True if name matches instance pattern, False otherwise
+        """
+        return bool(self._INSTANCE_PATTERN.match(name))

--- a/src/llm_orc/core/execution/fan_out_expander.py
+++ b/src/llm_orc/core/execution/fan_out_expander.py
@@ -1,0 +1,186 @@
+"""Fan-out agent expansion for parallel execution over arrays (issue #73)."""
+
+import json
+import re
+from typing import Any
+
+
+class FanOutExpander:
+    """Expands fan_out agents into N parallel instances at runtime."""
+
+    # Pattern for instance names: agent_name[index]
+    _INSTANCE_PATTERN = re.compile(r"^(.+)\[(\d+)\]$")
+
+    def detect_fan_out_agents(self, agent_configs: list[dict[str, Any]]) -> list[str]:
+        """Return names of agents with fan_out: true.
+
+        Args:
+            agent_configs: List of agent configurations
+
+        Returns:
+            List of agent names that have fan_out: true
+        """
+        return [
+            agent["name"] for agent in agent_configs if agent.get("fan_out") is True
+        ]
+
+    def is_array_result(self, result: Any) -> bool:
+        """Check if upstream result is a non-empty array.
+
+        Args:
+            result: Result from upstream agent (may be JSON string or Python list)
+
+        Returns:
+            True if result is a non-empty array, False otherwise
+        """
+        # Handle Python list directly
+        if isinstance(result, list):
+            return len(result) > 0
+
+        # Try parsing as JSON
+        if isinstance(result, str):
+            try:
+                parsed = json.loads(result)
+                return isinstance(parsed, list) and len(parsed) > 0
+            except (json.JSONDecodeError, TypeError):
+                return False
+
+        return False
+
+    def expand_fan_out_agent(
+        self,
+        agent_config: dict[str, Any],
+        upstream_array: list[Any],
+    ) -> list[dict[str, Any]]:
+        """Create N copies of agent config with indexed names.
+
+        Args:
+            agent_config: Original agent configuration with fan_out: true
+            upstream_array: Array from upstream agent to fan out over
+
+        Returns:
+            List of agent configs, one per array element, with indexed names
+        """
+        original_name = agent_config["name"]
+        instances = []
+
+        for index, chunk in enumerate(upstream_array):
+            # Create copy of config without fan_out field
+            instance_config = {
+                key: value for key, value in agent_config.items() if key != "fan_out"
+            }
+
+            # Set indexed name
+            instance_config["name"] = f"{original_name}[{index}]"
+
+            # Store chunk metadata for input preparation
+            instance_config["_fan_out_chunk"] = chunk
+            instance_config["_fan_out_index"] = index
+            instance_config["_fan_out_total"] = len(upstream_array)
+            instance_config["_fan_out_original"] = original_name
+
+            instances.append(instance_config)
+
+        return instances
+
+    def prepare_instance_input(
+        self,
+        chunk: Any,
+        chunk_index: int,
+        total_chunks: int,
+        base_input: str,
+    ) -> dict[str, Any]:
+        """Prepare input for a single fan-out instance.
+
+        Args:
+            chunk: The chunk content for this instance
+            chunk_index: Index of this chunk (0-based)
+            total_chunks: Total number of chunks
+            base_input: Original ensemble input
+
+        Returns:
+            Input dict with chunk content and metadata
+        """
+        return {
+            "input": chunk,
+            "chunk_index": chunk_index,
+            "total_chunks": total_chunks,
+            "base_input": base_input,
+        }
+
+    def is_fan_out_instance_name(self, name: str) -> bool:
+        """Check if name matches the fan-out instance pattern 'agent[N]'.
+
+        Args:
+            name: Agent name to check
+
+        Returns:
+            True if name matches instance pattern, False otherwise
+        """
+        return bool(self._INSTANCE_PATTERN.match(name))
+
+    def get_original_agent_name(self, instance_name: str) -> str:
+        """Extract original agent name from instance name.
+
+        Args:
+            instance_name: Instance name like 'extractor[0]'
+
+        Returns:
+            Original name like 'extractor', or input unchanged if not instance
+        """
+        match = self._INSTANCE_PATTERN.match(instance_name)
+        if match:
+            return match.group(1)
+        return instance_name
+
+    def get_instance_index(self, instance_name: str) -> int | None:
+        """Extract index from instance name.
+
+        Args:
+            instance_name: Instance name like 'extractor[42]'
+
+        Returns:
+            Index as int, or None if not an instance name
+        """
+        match = self._INSTANCE_PATTERN.match(instance_name)
+        if match:
+            return int(match.group(2))
+        return None
+
+    def parse_array_from_result(self, result: Any) -> list[Any] | None:
+        """Parse array from upstream agent result.
+
+        Handles:
+        - Python list directly
+        - JSON array string
+        - ScriptAgentOutput format with data field
+
+        Args:
+            result: Result from upstream agent
+
+        Returns:
+            Parsed array, or None if result is not an array
+        """
+        # Handle Python list directly
+        if isinstance(result, list):
+            return result
+
+        # Try parsing as JSON
+        if isinstance(result, str):
+            try:
+                parsed = json.loads(result)
+
+                # Direct array
+                if isinstance(parsed, list):
+                    return parsed
+
+                # ScriptAgentOutput format: {"success": true, "data": [...]}
+                if isinstance(parsed, dict):
+                    data = parsed.get("data")
+                    if isinstance(data, list):
+                        return data
+
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        return None

--- a/src/llm_orc/core/execution/fan_out_gatherer.py
+++ b/src/llm_orc/core/execution/fan_out_gatherer.py
@@ -1,0 +1,200 @@
+"""Fan-out result gathering for parallel agent execution (issue #73)."""
+
+from typing import Any
+
+from llm_orc.core.execution.fan_out_expander import FanOutExpander
+
+
+class FanOutGatherer:
+    """Gathers results from fan-out instances into ordered arrays."""
+
+    def __init__(self, expander: FanOutExpander) -> None:
+        """Initialize gatherer with expander for instance name parsing.
+
+        Args:
+            expander: FanOutExpander instance for parsing instance names
+        """
+        self._expander = expander
+        # Map: original_agent_name -> {index: (result, success, error)}
+        self._results: dict[str, dict[int, tuple[Any, bool, str | None]]] = {}
+
+    def record_instance_result(
+        self,
+        instance_name: str,
+        result: Any,
+        success: bool,
+        error: str | None = None,
+    ) -> None:
+        """Record result from a single fan-out instance.
+
+        Args:
+            instance_name: Instance name like 'extractor[0]'
+            result: Result from the instance execution
+            success: Whether the execution succeeded
+            error: Error message if failed
+        """
+        original_name = self._expander.get_original_agent_name(instance_name)
+        index = self._expander.get_instance_index(instance_name)
+
+        if index is None:
+            # Not a fan-out instance, treat as single result at index 0
+            index = 0
+
+        if original_name not in self._results:
+            self._results[original_name] = {}
+
+        self._results[original_name][index] = (result, success, error)
+
+    def has_instance_result(self, instance_name: str) -> bool:
+        """Check if a result has been recorded for an instance.
+
+        Args:
+            instance_name: Instance name like 'extractor[0]'
+
+        Returns:
+            True if result recorded, False otherwise
+        """
+        original_name = self._expander.get_original_agent_name(instance_name)
+        index = self._expander.get_instance_index(instance_name)
+
+        if index is None:
+            index = 0
+
+        return original_name in self._results and index in self._results[original_name]
+
+    def gather_results(self, original_agent_name: str) -> dict[str, Any]:
+        """Gather all instance results for an original agent.
+
+        Args:
+            original_agent_name: Original agent name (e.g., 'extractor')
+
+        Returns:
+            Dict with:
+            - response: Ordered list of results (None for failed instances)
+            - status: 'success' | 'partial' | 'failed'
+            - fan_out: True (marker for fan-out result)
+            - instances: Per-instance status info
+        """
+        if original_agent_name not in self._results:
+            return {
+                "response": [],
+                "status": "success",
+                "fan_out": True,
+                "instances": [],
+            }
+
+        instance_data = self._results[original_agent_name]
+
+        # Sort by index
+        sorted_indices = sorted(instance_data.keys())
+
+        response: list[Any] = []
+        instances: list[dict[str, Any]] = []
+        success_count = 0
+        fail_count = 0
+
+        for index in sorted_indices:
+            result, success, error = instance_data[index]
+
+            if success:
+                response.append(result)
+                success_count += 1
+                instances.append({"index": index, "status": "success"})
+            else:
+                response.append(None)
+                fail_count += 1
+                instances.append(
+                    {
+                        "index": index,
+                        "status": "failed",
+                        "error": error,
+                    }
+                )
+
+        # Determine overall status
+        if fail_count == 0:
+            status = "success"
+        elif success_count == 0:
+            status = "failed"
+        else:
+            status = "partial"
+
+        return {
+            "response": response,
+            "status": status,
+            "fan_out": True,
+            "instances": instances,
+        }
+
+    def get_error_summary(self, original_agent_name: str) -> dict[str, Any]:
+        """Get error details for failed instances.
+
+        Args:
+            original_agent_name: Original agent name
+
+        Returns:
+            Dict with total_instances, failed_count, success_count, errors
+        """
+        if original_agent_name not in self._results:
+            return {
+                "total_instances": 0,
+                "failed_count": 0,
+                "success_count": 0,
+                "errors": [],
+            }
+
+        instance_data = self._results[original_agent_name]
+        errors: list[dict[str, Any]] = []
+        success_count = 0
+        fail_count = 0
+
+        for index, (_, success, error) in instance_data.items():
+            if success:
+                success_count += 1
+            else:
+                fail_count += 1
+                errors.append({"index": index, "error": error})
+
+        return {
+            "total_instances": len(instance_data),
+            "failed_count": fail_count,
+            "success_count": success_count,
+            "errors": errors,
+        }
+
+    def has_pending_instances(
+        self, original_agent_name: str, expected_count: int
+    ) -> bool:
+        """Check if any instances are still pending.
+
+        Args:
+            original_agent_name: Original agent name
+            expected_count: Expected total number of instances
+
+        Returns:
+            True if not all instances have been recorded
+        """
+        recorded = self.get_recorded_count(original_agent_name)
+        return recorded < expected_count
+
+    def get_recorded_count(self, original_agent_name: str) -> int:
+        """Get number of recorded instances for an agent.
+
+        Args:
+            original_agent_name: Original agent name
+
+        Returns:
+            Count of recorded instances
+        """
+        if original_agent_name not in self._results:
+            return 0
+        return len(self._results[original_agent_name])
+
+    def clear(self, original_agent_name: str) -> None:
+        """Clear all recorded results for an agent.
+
+        Args:
+            original_agent_name: Original agent name to clear
+        """
+        if original_agent_name in self._results:
+            del self._results[original_agent_name]

--- a/tests/unit/core/execution/test_fan_out_expander.py
+++ b/tests/unit/core/execution/test_fan_out_expander.py
@@ -1,0 +1,244 @@
+"""Tests for fan-out agent expansion (issue #73)."""
+
+import json
+from typing import Any
+
+import pytest
+
+from llm_orc.core.execution.fan_out_expander import FanOutExpander
+
+
+class TestFanOutExpander:
+    """Test FanOutExpander functionality."""
+
+    @pytest.fixture
+    def expander(self) -> FanOutExpander:
+        """Create a FanOutExpander instance."""
+        return FanOutExpander()
+
+    def test_detect_fan_out_agents_returns_names(
+        self, expander: FanOutExpander
+    ) -> None:
+        """detect_fan_out_agents returns names of agents with fan_out: true."""
+        agents: list[dict[str, Any]] = [
+            {"name": "chunker", "script": "split.py"},
+            {"name": "extractor", "model_profile": "test", "fan_out": True},
+            {"name": "synthesizer", "model_profile": "test"},
+            {"name": "analyzer", "model_profile": "test", "fan_out": True},
+        ]
+
+        result = expander.detect_fan_out_agents(agents)
+
+        assert result == ["extractor", "analyzer"]
+
+    def test_detect_fan_out_agents_empty_list(self, expander: FanOutExpander) -> None:
+        """detect_fan_out_agents returns empty list when no fan_out agents."""
+        agents: list[dict[str, Any]] = [
+            {"name": "agent1", "model_profile": "test"},
+            {"name": "agent2", "model_profile": "test", "fan_out": False},
+        ]
+
+        result = expander.detect_fan_out_agents(agents)
+
+        assert result == []
+
+    def test_is_array_result_true_for_json_array_string(
+        self, expander: FanOutExpander
+    ) -> None:
+        """is_array_result returns True for JSON array string."""
+        result = expander.is_array_result('["chunk1", "chunk2", "chunk3"]')
+
+        assert result is True
+
+    def test_is_array_result_true_for_python_list(
+        self, expander: FanOutExpander
+    ) -> None:
+        """is_array_result returns True for Python list."""
+        result = expander.is_array_result(["chunk1", "chunk2"])
+
+        assert result is True
+
+    def test_is_array_result_false_for_dict(self, expander: FanOutExpander) -> None:
+        """is_array_result returns False for dict."""
+        result = expander.is_array_result({"key": "value"})
+
+        assert result is False
+
+    def test_is_array_result_false_for_json_object_string(
+        self, expander: FanOutExpander
+    ) -> None:
+        """is_array_result returns False for JSON object string."""
+        result = expander.is_array_result('{"key": "value"}')
+
+        assert result is False
+
+    def test_is_array_result_false_for_plain_string(
+        self, expander: FanOutExpander
+    ) -> None:
+        """is_array_result returns False for plain string."""
+        result = expander.is_array_result("just a plain string")
+
+        assert result is False
+
+    def test_is_array_result_false_for_empty_array(
+        self, expander: FanOutExpander
+    ) -> None:
+        """is_array_result returns False for empty array (nothing to fan out)."""
+        result = expander.is_array_result([])
+
+        assert result is False
+
+    def test_expand_fan_out_agent_creates_indexed_copies(
+        self, expander: FanOutExpander
+    ) -> None:
+        """expand_fan_out_agent creates N indexed copies of agent config."""
+        agent_config: dict[str, Any] = {
+            "name": "extractor",
+            "model_profile": "ollama-llama3",
+            "fan_out": True,
+            "depends_on": ["chunker"],
+            "system_prompt": "Extract concepts",
+        }
+        upstream_array = ["chunk1", "chunk2", "chunk3"]
+
+        result = expander.expand_fan_out_agent(agent_config, upstream_array)
+
+        assert len(result) == 3
+        assert result[0]["name"] == "extractor[0]"
+        assert result[1]["name"] == "extractor[1]"
+        assert result[2]["name"] == "extractor[2]"
+        # Original config preserved
+        assert result[0]["model_profile"] == "ollama-llama3"
+        assert result[0]["system_prompt"] == "Extract concepts"
+        # fan_out removed from instances
+        assert "fan_out" not in result[0]
+
+    def test_expand_fan_out_agent_stores_chunk_info(
+        self, expander: FanOutExpander
+    ) -> None:
+        """expand_fan_out_agent stores chunk metadata in each instance."""
+        agent_config: dict[str, Any] = {
+            "name": "extractor",
+            "model_profile": "test",
+            "fan_out": True,
+            "depends_on": ["chunker"],
+        }
+        upstream_array = ["chunk_a", "chunk_b"]
+
+        result = expander.expand_fan_out_agent(agent_config, upstream_array)
+
+        assert result[0]["_fan_out_chunk"] == "chunk_a"
+        assert result[0]["_fan_out_index"] == 0
+        assert result[0]["_fan_out_total"] == 2
+        assert result[0]["_fan_out_original"] == "extractor"
+
+        assert result[1]["_fan_out_chunk"] == "chunk_b"
+        assert result[1]["_fan_out_index"] == 1
+        assert result[1]["_fan_out_total"] == 2
+        assert result[1]["_fan_out_original"] == "extractor"
+
+    def test_prepare_instance_input_includes_chunk_metadata(
+        self, expander: FanOutExpander
+    ) -> None:
+        """prepare_instance_input includes chunk index and total."""
+        result = expander.prepare_instance_input(
+            chunk="Scene 1 content",
+            chunk_index=0,
+            total_chunks=5,
+            base_input="Analyze this play",
+        )
+
+        assert result["input"] == "Scene 1 content"
+        assert result["chunk_index"] == 0
+        assert result["total_chunks"] == 5
+        assert result["base_input"] == "Analyze this play"
+
+    def test_prepare_instance_input_with_dict_chunk(
+        self, expander: FanOutExpander
+    ) -> None:
+        """prepare_instance_input handles dict chunk content."""
+        chunk = {"scene": "Act 1 Scene 2", "text": "Some dialogue"}
+        result = expander.prepare_instance_input(
+            chunk=chunk,
+            chunk_index=2,
+            total_chunks=10,
+            base_input="Extract themes",
+        )
+
+        assert result["input"] == chunk
+        assert result["chunk_index"] == 2
+        assert result["total_chunks"] == 10
+
+    def test_is_fan_out_instance_name_pattern_matching(
+        self, expander: FanOutExpander
+    ) -> None:
+        """is_fan_out_instance_name correctly identifies instance names."""
+        assert expander.is_fan_out_instance_name("extractor[0]") is True
+        assert expander.is_fan_out_instance_name("extractor[42]") is True
+        assert expander.is_fan_out_instance_name("my-agent[123]") is True
+        assert expander.is_fan_out_instance_name("extractor") is False
+        assert expander.is_fan_out_instance_name("extractor[]") is False
+        assert expander.is_fan_out_instance_name("extractor[abc]") is False
+        assert expander.is_fan_out_instance_name("[0]") is False
+
+    def test_get_original_agent_name_extraction(self, expander: FanOutExpander) -> None:
+        """get_original_agent_name extracts original name from instance name."""
+        assert expander.get_original_agent_name("extractor[0]") == "extractor"
+        assert expander.get_original_agent_name("extractor[42]") == "extractor"
+        assert expander.get_original_agent_name("my-agent[5]") == "my-agent"
+
+    def test_get_original_agent_name_returns_input_if_not_instance(
+        self, expander: FanOutExpander
+    ) -> None:
+        """get_original_agent_name returns input unchanged if not instance name."""
+        assert expander.get_original_agent_name("extractor") == "extractor"
+        assert expander.get_original_agent_name("my-agent") == "my-agent"
+
+    def test_get_instance_index(self, expander: FanOutExpander) -> None:
+        """get_instance_index extracts index from instance name."""
+        assert expander.get_instance_index("extractor[0]") == 0
+        assert expander.get_instance_index("extractor[42]") == 42
+        assert expander.get_instance_index("my-agent[123]") == 123
+
+    def test_get_instance_index_returns_none_if_not_instance(
+        self, expander: FanOutExpander
+    ) -> None:
+        """get_instance_index returns None if not an instance name."""
+        assert expander.get_instance_index("extractor") is None
+        assert expander.get_instance_index("my-agent") is None
+
+    def test_parse_array_from_result_json_string(
+        self, expander: FanOutExpander
+    ) -> None:
+        """parse_array_from_result parses JSON array string."""
+        result = expander.parse_array_from_result('["a", "b", "c"]')
+
+        assert result == ["a", "b", "c"]
+
+    def test_parse_array_from_result_list(self, expander: FanOutExpander) -> None:
+        """parse_array_from_result returns list as-is."""
+        result = expander.parse_array_from_result(["a", "b"])
+
+        assert result == ["a", "b"]
+
+    def test_parse_array_from_result_script_output(
+        self, expander: FanOutExpander
+    ) -> None:
+        """parse_array_from_result handles ScriptAgentOutput format."""
+        script_output = json.dumps(
+            {
+                "success": True,
+                "data": ["chunk1", "chunk2"],
+            }
+        )
+        result = expander.parse_array_from_result(script_output)
+
+        assert result == ["chunk1", "chunk2"]
+
+    def test_parse_array_from_result_returns_none_for_non_array(
+        self, expander: FanOutExpander
+    ) -> None:
+        """parse_array_from_result returns None for non-array input."""
+        assert expander.parse_array_from_result("plain string") is None
+        assert expander.parse_array_from_result('{"key": "value"}') is None
+        assert expander.parse_array_from_result({"key": "value"}) is None

--- a/tests/unit/core/execution/test_fan_out_gatherer.py
+++ b/tests/unit/core/execution/test_fan_out_gatherer.py
@@ -1,0 +1,178 @@
+"""Tests for fan-out result gathering (issue #73)."""
+
+import pytest
+
+from llm_orc.core.execution.fan_out_expander import FanOutExpander
+from llm_orc.core.execution.fan_out_gatherer import FanOutGatherer
+
+
+class TestFanOutGatherer:
+    """Test FanOutGatherer functionality."""
+
+    @pytest.fixture
+    def expander(self) -> FanOutExpander:
+        """Create a FanOutExpander instance."""
+        return FanOutExpander()
+
+    @pytest.fixture
+    def gatherer(self, expander: FanOutExpander) -> FanOutGatherer:
+        """Create a FanOutGatherer instance."""
+        return FanOutGatherer(expander)
+
+    def test_record_instance_result_success(self, gatherer: FanOutGatherer) -> None:
+        """record_instance_result stores successful result."""
+        gatherer.record_instance_result(
+            instance_name="extractor[0]",
+            result={"concepts": ["theme1"]},
+            success=True,
+        )
+
+        # Should be tracked
+        assert gatherer.has_instance_result("extractor[0]")
+
+    def test_record_instance_result_failure(self, gatherer: FanOutGatherer) -> None:
+        """record_instance_result stores failed result with error."""
+        gatherer.record_instance_result(
+            instance_name="extractor[1]",
+            result=None,
+            success=False,
+            error="timeout after 60s",
+        )
+
+        # Should be tracked
+        assert gatherer.has_instance_result("extractor[1]")
+
+    def test_gather_results_orders_by_index(self, gatherer: FanOutGatherer) -> None:
+        """gather_results returns results ordered by instance index."""
+        # Record out of order
+        gatherer.record_instance_result("extractor[2]", "result_2", True)
+        gatherer.record_instance_result("extractor[0]", "result_0", True)
+        gatherer.record_instance_result("extractor[1]", "result_1", True)
+
+        result = gatherer.gather_results("extractor")
+
+        assert result["response"] == ["result_0", "result_1", "result_2"]
+        assert result["status"] == "success"
+        assert result["fan_out"] is True
+
+    def test_gather_results_partial_on_some_failures(
+        self, gatherer: FanOutGatherer
+    ) -> None:
+        """gather_results returns partial status when some instances fail."""
+        gatherer.record_instance_result("extractor[0]", "result_0", True)
+        gatherer.record_instance_result("extractor[1]", None, False, error="timeout")
+        gatherer.record_instance_result("extractor[2]", "result_2", True)
+
+        result = gatherer.gather_results("extractor")
+
+        assert result["status"] == "partial"
+        assert result["response"] == ["result_0", None, "result_2"]
+        assert len(result["instances"]) == 3
+        assert result["instances"][1]["status"] == "failed"
+        assert result["instances"][1]["error"] == "timeout"
+
+    def test_gather_results_failed_on_all_failures(
+        self, gatherer: FanOutGatherer
+    ) -> None:
+        """gather_results returns failed status when all instances fail."""
+        gatherer.record_instance_result("extractor[0]", None, False, error="error_0")
+        gatherer.record_instance_result("extractor[1]", None, False, error="error_1")
+
+        result = gatherer.gather_results("extractor")
+
+        assert result["status"] == "failed"
+        assert result["response"] == [None, None]
+
+    def test_gather_results_instance_statuses(self, gatherer: FanOutGatherer) -> None:
+        """gather_results includes per-instance status information."""
+        gatherer.record_instance_result("analyzer[0]", {"data": "a"}, True)
+        gatherer.record_instance_result(
+            "analyzer[1]", None, False, error="network error"
+        )
+
+        result = gatherer.gather_results("analyzer")
+
+        assert len(result["instances"]) == 2
+        assert result["instances"][0]["index"] == 0
+        assert result["instances"][0]["status"] == "success"
+        assert result["instances"][1]["index"] == 1
+        assert result["instances"][1]["status"] == "failed"
+        assert result["instances"][1]["error"] == "network error"
+
+    def test_get_error_summary(self, gatherer: FanOutGatherer) -> None:
+        """get_error_summary returns error details for failed instances."""
+        gatherer.record_instance_result("extractor[0]", "ok", True)
+        gatherer.record_instance_result("extractor[1]", None, False, error="timeout")
+        gatherer.record_instance_result(
+            "extractor[2]", None, False, error="rate limited"
+        )
+
+        summary = gatherer.get_error_summary("extractor")
+
+        assert summary["total_instances"] == 3
+        assert summary["failed_count"] == 2
+        assert summary["success_count"] == 1
+        assert len(summary["errors"]) == 2
+        assert {"index": 1, "error": "timeout"} in summary["errors"]
+        assert {"index": 2, "error": "rate limited"} in summary["errors"]
+
+    def test_get_error_summary_no_errors(self, gatherer: FanOutGatherer) -> None:
+        """get_error_summary returns empty errors list when all succeed."""
+        gatherer.record_instance_result("extractor[0]", "ok", True)
+        gatherer.record_instance_result("extractor[1]", "ok", True)
+
+        summary = gatherer.get_error_summary("extractor")
+
+        assert summary["failed_count"] == 0
+        assert summary["success_count"] == 2
+        assert summary["errors"] == []
+
+    def test_has_pending_instances_true(self, gatherer: FanOutGatherer) -> None:
+        """has_pending_instances returns True when not all recorded."""
+        # Only record 2 of expected 3
+        gatherer.record_instance_result("extractor[0]", "ok", True)
+        gatherer.record_instance_result("extractor[1]", "ok", True)
+
+        # Should have pending if we expected 3
+        assert gatherer.has_pending_instances("extractor", expected_count=3)
+
+    def test_has_pending_instances_false(self, gatherer: FanOutGatherer) -> None:
+        """has_pending_instances returns False when all recorded."""
+        gatherer.record_instance_result("extractor[0]", "ok", True)
+        gatherer.record_instance_result("extractor[1]", "ok", True)
+
+        assert not gatherer.has_pending_instances("extractor", expected_count=2)
+
+    def test_get_recorded_count(self, gatherer: FanOutGatherer) -> None:
+        """get_recorded_count returns number of recorded instances."""
+        assert gatherer.get_recorded_count("extractor") == 0
+
+        gatherer.record_instance_result("extractor[0]", "ok", True)
+        assert gatherer.get_recorded_count("extractor") == 1
+
+        gatherer.record_instance_result("extractor[1]", "ok", True)
+        assert gatherer.get_recorded_count("extractor") == 2
+
+    def test_clear_clears_all_recorded_results(self, gatherer: FanOutGatherer) -> None:
+        """clear removes all recorded results for an agent."""
+        gatherer.record_instance_result("extractor[0]", "ok", True)
+        gatherer.record_instance_result("extractor[1]", "ok", True)
+
+        gatherer.clear("extractor")
+
+        assert gatherer.get_recorded_count("extractor") == 0
+
+    def test_multiple_agents_tracked_independently(
+        self, gatherer: FanOutGatherer
+    ) -> None:
+        """Multiple fan-out agents are tracked independently."""
+        gatherer.record_instance_result("extractor[0]", "e0", True)
+        gatherer.record_instance_result("analyzer[0]", "a0", True)
+        gatherer.record_instance_result("extractor[1]", "e1", True)
+        gatherer.record_instance_result("analyzer[1]", "a1", True)
+
+        extractor_result = gatherer.gather_results("extractor")
+        analyzer_result = gatherer.gather_results("analyzer")
+
+        assert extractor_result["response"] == ["e0", "e1"]
+        assert analyzer_result["response"] == ["a0", "a1"]


### PR DESCRIPTION
## Summary

Implements issue #73 - fan-out/map-reduce pattern for agents that process arrays in parallel.

When an agent has `fan_out: true` and its upstream dependency returns an array, the agent is automatically expanded into N parallel instances (e.g., `processor[0]`, `processor[1]`, `processor[2]`) that each process one chunk. Results are gathered back under the original agent name with status tracking per instance.

### Key Features

- **Automatic array detection**: Parses JSON arrays and `{"data": [...]}` script outputs
- **Parallel execution**: Fan-out instances run concurrently within the same phase
- **Result gathering**: Ordered array of results with per-instance status tracking
- **Partial success**: Continues with available results on instance failures
- **Minimal API**: Only adds `fan_out: true` field - everything else is implicit

### Files Changed

**New modules:**
- `fan_out_expander.py` - Detects arrays, expands agents into indexed instances
- `fan_out_gatherer.py` - Collects and orders instance results

**Integration:**
- `ensemble_execution.py` - Phase execution with fan-out support
- `dependency_resolver.py` - Chunk-indexed input preparation
- `dependency_analyzer.py` - Instance name normalization
- `ensemble_config.py` - Validation (fan_out requires depends_on)
- `artifact_manager.py` - Markdown reports with fan-out sections
- `results_processor.py` - Fan-out stats aggregation
- `visualization.py`, `results_display.py` - Handle list responses

**Test ensemble:**
- `.llm-orc/ensembles/fan-out-test.yaml` with chunker + processor scripts

## Test plan

- [x] 60 new fan-out unit tests passing
- [x] All 2604 tests passing
- [x] Tested via CLI: `llm-orc invoke fan-out-test "..."`
- [x] Tested via MCP: `mcp__llm-orc__invoke`
- [x] mypy and ruff checks pass

Closes #73