### PR TITLE
Stage 2 core: wire observation + full-history selection; gate runner and shape fixes

### DIFF
--- a/.llm-orc/scripts/agentic_serving/accept_executor_runner.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor_runner.py
@@ -36,21 +36,47 @@ def run_tests(code: str, tests: str) -> tuple[bool, str, int]:
     test_fns = [
         (name, fn)
         for name, fn in namespace.items()
-        if name.startswith("test_") and callable(fn)
+        if name.startswith("test_") and callable(fn) and not isinstance(fn, type)
     ]
-    if not test_fns:
-        return False, "no test_* functions found", 0
+
+    # unittest.TestCase classes are the other common seat-model dialect
+    # ('no test_* functions found' otherwise rejects perfectly good tests)
+    import unittest
+
+    case_classes = [
+        obj
+        for obj in namespace.values()
+        if isinstance(obj, type)
+        and issubclass(obj, unittest.TestCase)
+        and obj is not unittest.TestCase
+    ]
 
     failures: list[str] = []
+    n_tests = 0
+
     for name, fn in test_fns:
+        n_tests += 1
         try:
             fn()
         except Exception as error:  # noqa: BLE001
             failures.append(f"{name}: {error!r}")
 
+    if case_classes:
+        loader = unittest.defaultTestLoader
+        suite = unittest.TestSuite(
+            loader.loadTestsFromTestCase(case) for case in case_classes
+        )
+        result = unittest.TestResult()
+        suite.run(result)
+        n_tests += result.testsRun
+        for test, trace in result.failures + result.errors:
+            failures.append(f"{test}: {trace.strip().splitlines()[-1]}")
+
+    if n_tests == 0:
+        return False, "no test_* functions or TestCase classes found", 0
     if failures:
-        return False, "; ".join(failures), len(test_fns)
-    return True, "all passed", len(test_fns)
+        return False, "; ".join(failures), n_tests
+    return True, "all passed", n_tests
 
 
 def main() -> None:

--- a/docs/serving-roadmap.md
+++ b/docs/serving-roadmap.md
@@ -27,16 +27,22 @@ reject on hard turns is judge conservatism — judge false-reject rate is now
 the measurement target (#84). The exit gate (ladder ≥ 7/8) is pending a
 full post-release ladder rerun.
 
-## Stage 2 — Memory rung 2′: lossless session record + selection (#82)
+## Stage 2 — Memory rung 2′: lossless selection (#82) — CORE SHIPPED (PR #99)
 
-Replace the rung-1 window with the lossless per-session record and
-deterministic referent selection (design:
-`docs/plans/2026-07-08-serving-conversation-memory-design.md`). Clears the
-cross-file/window-loss failure (turn 6: correct code, starved sandbox).
-Entry gate: observe OpenCode's compacted wire on one long session before
-hardening the divergence classifier (rebuild-from-wire is the interim
-fallback). Exit gate: the cross-file ladder turn passes; a 20+-turn session
-retains turn-1 referents.
+The entry-gate observation (real 9-turn multi-file session, wire-shape
+instrumentation): OpenCode's wire is append-only, prefix hashes stable, NO
+compaction through 30+ messages — so the lossless record is already on the
+wire. The core shipped as stateless deterministic selection over the full
+client-sent history: recency tail + every conversation-written file's
+latest version (task-referenced first). Exit-gate evidence: 8/9 on the
+long-horizon battery, including the previously-failing cross-file build and
+a precise turn-1 recall at turn 8. Remaining (kept on #82): the server-side
+record + divergence classifier, deferred until client compaction is
+actually observed; prose-turn retrieval beyond the tail. New stage-1
+refinement from the drive: #100 — the retry round should hold passing tests
+fixed and regenerate only the code (the TDD loop); spec-freedom
+disagreement between resampled tests and code is now the dominant
+hard-turn failure.
 
 ## Stage 3 — Client execution surface (#83)
 

--- a/docs/serving-roadmap.md
+++ b/docs/serving-roadmap.md
@@ -3,88 +3,127 @@
 **North star:** full model parity through composition (see `docs/serving.md`)
 — the endpoint does everything a strong single model does behind a coding
 tool, at ~zero marginal cost, and then exceeds it where composition has
-structural advantages (verified acceptance, lossless memory, provenance).
+structural advantages. Concretely, "comparable or superior to a frontier
+model (latency notwithstanding)" decomposes into three levers a monolithic
+model does not have:
 
-**How progress is measured:** the 8-turn escalating ladder (build → edit →
-tests → explain-why → second module → cross-file → run-tests → refactor),
-driven through real OpenCode, scored per-turn against the same ladder run
-with an Anthropic model (Haiku 4.5 / Sonnet 5) as the backend. The Cycle-7
-benchmark harness on `research/agentic-serving-corpus` (`benchmark-runs/`)
-is the automation to revive for this. Baseline 2026-07-08: 4/8 → 5/8 after
-the pre-release fixes; ~55–60% of the Haiku-backed experience.
-**Released as v0.18.0 (2026-07-09)** after an 8-angle review pass (8
-correctness findings fixed pre-merge; deferred findings tracked as #91–#96).
+1. **Verified acceptance** — deliverables pass a deterministic executor and
+   an independent judge before they ship; a raw model never checks its work.
+2. **Lossless memory** — deterministic selection over the full history (and
+   eventually cross-session substrate) instead of attention over a decaying
+   context window.
+3. **Zero marginal cost** — systematic coverage (more rounds, more
+   verification, more retrieval) is free where every frontier token is
+   billed.
 
-## Stage 1 — Reliability: the accept-gate retry round (#89) — SHIPPED in v0.18.0
+Latency is the accepted trade; correctness and memory are where we compete.
 
-The dominant failure class — confirmed on BOTH seat tiers (local qwen3:8b
-and qwen3.6-plus via Zen) — was one wrong expectation among ~5 generated
-tests killing an otherwise-correct turn. Shipped: build-gated wraps
-build-gated-round in the engine's `loop:` primitive (bounded, carry = the
-executor's failure report). **Key finding from the A/B: structure is the
-lever, not model size.** Live observation with retries wired: the residual
-reject on hard turns is judge conservatism — judge false-reject rate is now
-the measurement target (#84). The exit gate (ladder ≥ 7/8) is pending a
-full post-release ladder rerun.
+## How progress is measured
 
-## Stage 2 — Memory rung 2′: lossless selection (#82) — CORE SHIPPED (PR #99)
+The escalating multi-turn ladder driven through **real OpenCode** (never
+harness-only), scored per turn against the same ladder with an Anthropic
+model as the backend. Trajectory so far:
 
-The entry-gate observation (real 9-turn multi-file session, wire-shape
-instrumentation): OpenCode's wire is append-only, prefix hashes stable, NO
-compaction through 30+ messages — so the lossless record is already on the
-wire. The core shipped as stateless deterministic selection over the full
-client-sent history: recency tail + every conversation-written file's
-latest version (task-referenced first). Exit-gate evidence: 8/9 on the
-long-horizon battery, including the previously-failing cross-file build and
-a precise turn-1 recall at turn 8. Remaining (kept on #82): the server-side
-record + divergence classifier, deferred until client compaction is
-actually observed; prose-turn retrieval beyond the tail. New stage-1
-refinement from the drive: #100 — the retry round should hold passing tests
-fixed and regenerate only the code (the TDD loop); spec-freedom
-disagreement between resampled tests and code is now the dominant
-hard-turn failure.
+| Date | Battery | Score | Notes |
+|------|---------|-------|-------|
+| 2026-07-08 (arc start) | 8-turn ladder | 4/8 | silent wrong verdicts |
+| 2026-07-08 (v0.18.0) | 8-turn ladder | 5/8 | all failures honest rejects |
+| 2026-07-09 (Stage 2 core) | 9-turn todo app | **8/9** | multi-file build + deep recall pass; one honest reject |
 
-## Stage 3 — Client execution surface (#83)
+The Cycle-7 benchmark harness (`research/agentic-serving-corpus` branch,
+`benchmark-runs/`) is the automation to revive for a standing
+parity-percentage arm (Haiku 4.5 / Sonnet 5 behind OpenCode as baseline).
+
+## Current state (2026-07-09)
+
+Released: **v0.18.0** (agentic serving) and **v0.18.1** (review-debt sweep).
+Pending review: **PR #99** — Stage 2 core (wire observation + full-history
+selection + gate-runner TestCase support).
+
+Shipped capability: build (accept-gated, bounded retry), explain,
+edit-existing (conversation-written files), within-session memory with
+lossless file selection, deterministic routing with a guarded decider.
+All-local (qwen3:8b) by default; operator seat overrides via `*.local.yaml`.
+
+Key empirical facts the next work builds on:
+
+- OpenCode's wire is **append-only** (stable prefix hashes, no compaction
+  through 30+ messages) — `LLM_ORC_SERVE_WIRE_LOG` watches for the day that
+  changes.
+- **Structure beats model size**: the seat A/B showed a hosted frontier
+  model does not fix the dominant failure classes; shape and verification
+  changes do.
+- The dominant hard-turn failure is now **spec-freedom divergence**:
+  independently resampled tests and code disagree on choices the spec
+  leaves open.
+
+## The path, in order of leverage
+
+### 1. TDD retry loop (#100) — next up
+
+On a gate reject where round 1's tests loaded and ran, hold those tests
+fixed as the spec and regenerate only the code (regenerate tests only when
+they failed to collect). Directly attacks the spec-freedom failure (the one
+lost turn in the 9-turn battery) and strengthens ADR-048's
+criteria-primacy: round 1's tests become round 2's concrete criteria.
+Exit gate: the cli.py-style integration turn passes; ladder ≥ 9/9.
+
+### 2. Client execution surface (#83)
 
 Files the conversation didn't write, and running things: thread client
-read-tool results into the turn, and/or client-delegated execution (the
-emit node's permission seam reused for a test-run tool_call — ADR-048
-ODP-1). Closes run-tests (today: narration, not action) and fix/edit on
-pre-existing files — the two biggest parity holes. Exit gate: "run the
-tests" executes; editing a file the serve never wrote round-trips.
+read-tool results into the turn and/or client-delegated execution (emit's
+permission seam reused for a test-run tool_call — ADR-048 ODP-1). Includes
+the tool-mapping step (resolve emit outcomes against the client's
+advertised tools instead of the hardcoded `write`). Closes run-tests and
+pre-existing-file editing — the two biggest remaining parity holes.
 
-## Stage 4 — Shapes and seat tiering
+### 3. Gate integrity pair (#98, #84)
 
-Operator-curated catalog growth on the ADR-047 registry: a fix shape, a
-refactor shape, grounded-explain (file-reading explain seat). Per-seat
-escalation (local 14b / Zen qwen3.6-plus) on failure signals rather than by
-default — the 2026-07-08 A/B showed the default stays local-first. The
-elicit-then-build shape (criteria-first) graduates from fallback to a
-selectable catalog entry.
+#98: test-writing turns validate a shadowed composite in the shared exec
+namespace — route "write tests" to a dedicated shape (the deliverable IS
+the test file, run against the materialized workspace alone). #84: measure
+judge false-reject rate on fixtures (with retries wired, judge conservatism
+is the visible bottleneck on hard turns) and revisit ADR-048 §5's
+AND-vs-weighted composition with data.
 
-## Stage 5 — Beyond parity: the plexus substrate (rung 3)
+### 4. Shapes and seat tiering
 
-The session record ingests into a plexus knowledge graph; per-dispatch
-slices become provenance-tracked lens queries, cross-session. This is where
-the serve stops chasing a single model and passes it: memory with no
-recency decay, provenance on every remembered fact, knowledge that
-accumulates across sessions. Composes with the accept gate's contract
-hierarchy (assume-guarantee direction noted at Cycle-8 close).
+Operator-curated catalog growth: fix shape, refactor shape,
+grounded-explain (file-reading explain seat), elicit-then-build
+(criteria-first) as a selectable entry. Escalation-on-signal seat tiering
+(local 14b / hosted) — the default stays local-first per the A/B result.
+
+### 5. Memory remainder (#82) and beyond-parity
+
+Kept on #82: the server-side record + divergence classifier, deliberately
+deferred until client compaction is actually observed on the wire; and
+prose-turn retrieval beyond the recency tail (only files retrieve from deep
+history today). Beyond parity: the record ingests into a plexus knowledge
+graph, per-dispatch slices become provenance-tracked lens queries, and
+memory becomes cross-session with no recency decay — where the serve passes
+a single model rather than chasing it.
+
+### 6. Bootstrapping and hardening
+
+#90 llama.cpp as a built-in backend (drop the Ollama process dependency —
+clear-cut default-model bootstrap); #85 sandbox hardening
+(container/seccomp) before untrusted deployment; #93/#95 remainders
+(executor reuse + registry-scan caching; dead-field and prime-machinery
+removal).
 
 ## Standing constraints
 
 - 32GB rig is the permanent target; interactive latency is first-class.
-- Local-first defaults; hosted seats (Zen subscription) are operator opt-in.
-- Every stage lands with its ladder rerun and the parity score updated here.
-- Deterministic control, model judgment only inside bounded, closed-set,
+- Local-first defaults; hosted seats are operator opt-in, never tracked.
+- Real-client validation at the earliest runnable point; every stage lands
+  with its ladder rerun and the trajectory table updated.
+- Deterministic control; model judgment only inside bounded, closed-set,
   gate-backstopped decisions.
 
 ## Issue index
 
-Roadmap stages: #82 lossless record (Stage 2) · #83 client execution
-(Stage 3) · #84 accept-gate harness + judge false-reject measurement ·
-#85 sandbox hardening · #90 llama.cpp backend (bootstrapping).
-Review debt remaining: #93 (executor reuse + registry-scan caching) ·
-#95 (dead EnsembleConfig fields + prime machinery removal).
-Shipped: #87, #88, #89 (v0.18.0); #86, #91, #92, #94, #96 and the safe
-halves of #93/#95 (v0.18.1).
+Path: #100 TDD retry · #83 client execution · #98 test-shape gate ·
+#84 judge measurement · #82 memory remainder · #90 llama.cpp ·
+#85 sandbox hardening · #93/#95 remainders.
+Shipped: #87 #88 #89 (v0.18.0) · #86 #91 #92 #94 #96 (v0.18.1) ·
+#82-core + gate-runner TestCase support (PR #99).

--- a/src/llm_orc/web/api/v1_chat_completions.py
+++ b/src/llm_orc/web/api/v1_chat_completions.py
@@ -23,6 +23,9 @@ WP-F8; the declarative Serving Ensemble is the only path.
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
 import time
 import uuid
 from collections.abc import AsyncIterator
@@ -66,6 +69,43 @@ def get_session_registry() -> SessionRegistry:
 def get_session_start_cache() -> SessionStartCache:
     """Return the process-scoped session-start cache."""
     return _SHARED_SESSION_START_CACHE
+
+
+def _log_wire_shape(request: _ChatCompletionsRequest) -> None:
+    """Append one JSONL row describing the request's message shape.
+
+    Enabled by ``LLM_ORC_SERVE_WIRE_LOG=<path>`` — the issue #82 entry-gate
+    instrumentation for observing client-side history rewrites (compaction,
+    forks) on the wire. Records roles, content lengths, and a rolling
+    prefix-hash chain; never the content itself. The prefix hashes make a
+    client rewrite visible as a divergence point between requests.
+    """
+    log_path = os.environ.get("LLM_ORC_SERVE_WIRE_LOG")
+    if not log_path:
+        return
+    rows = []
+    digest = hashlib.sha256()
+    for message in request.messages:
+        content = message.content or ""
+        digest.update(f"{message.role}\x00{content}\x00".encode())
+        rows.append(
+            {
+                "role": message.role,
+                "content_len": len(content),
+                "tool_calls": len(message.tool_calls or []),
+                "prefix_hash": digest.hexdigest()[:12],
+            }
+        )
+    row = {
+        "ts": time.time(),
+        "message_count": len(request.messages),
+        "messages": rows,
+    }
+    try:
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(row) + "\n")
+    except OSError:  # observation must never break serving
+        pass
 
 
 def _resolve_serving_project_dir() -> Path:
@@ -133,6 +173,7 @@ async def chat_completions(
     introspection is the vendor-neutral turn trace.
     """
     context = _resolve_context(request)
+    _log_wire_shape(request)
     serving_caller: _ChatCompletionsCaller = get_serving_ensemble_caller()
     if request.stream:
         return StreamingResponse(

--- a/src/llm_orc/web/serving/serving_ensemble_caller.py
+++ b/src/llm_orc/web/serving/serving_ensemble_caller.py
@@ -126,10 +126,27 @@ def _render_context(messages: Sequence[Any]) -> str:
         if line.startswith("assistant: [wrote ")
     }
     blocks = [block for path, block in selected if path not in tail_paths]
-    if blocks:
-        selected_text = "\n".join(blocks)[:_CTX_SELECTED_CAP]
+    kept = _whole_blocks_within_cap(blocks)
+    if kept:
+        selected_text = "\n".join(kept)
         rendered = f"{selected_text}\n{rendered}" if rendered else selected_text
     return rendered
+
+
+def _whole_blocks_within_cap(blocks: list[str]) -> list[str]:
+    """Whole blocks up to ``_CTX_SELECTED_CAP`` — cap pressure drops whole
+    blocks (referenced-first ordering puts the least relevant last), never a
+    mid-block cut: an intact ``[wrote path]`` header over a silently cut body
+    would make gather materialize a corrupted file."""
+    kept: list[str] = []
+    size = 0
+    for block in blocks:
+        cost = len(block) + (1 if kept else 0)
+        if size + cost > _CTX_SELECTED_CAP:
+            break
+        kept.append(block)
+        size += cost
+    return kept
 
 
 def _select_written_files(older: Sequence[Any], task: str) -> list[tuple[str, str]]:

--- a/src/llm_orc/web/serving/serving_ensemble_caller.py
+++ b/src/llm_orc/web/serving/serving_ensemble_caller.py
@@ -119,37 +119,52 @@ def _render_context(messages: Sequence[Any]) -> str:
         rendered = rendered[cut + 1 :] if cut >= 0 else rendered
 
     task = _task_from(messages)
-    selected = _select_referenced_writes(conversational[: -len(tail) or None], task)
-    selected = [block for block in selected if block.splitlines()[0] not in rendered]
-    if selected:
-        selected_text = "\n".join(selected)[:_CTX_SELECTED_CAP]
+    selected = _select_written_files(conversational[: -len(tail) or None], task)
+    tail_paths = {
+        line.split("[wrote ", 1)[1].split("]", 1)[0].removesuffix(" (truncated)")
+        for line in rendered.splitlines()
+        if line.startswith("assistant: [wrote ")
+    }
+    blocks = [block for path, block in selected if path not in tail_paths]
+    if blocks:
+        selected_text = "\n".join(blocks)[:_CTX_SELECTED_CAP]
         rendered = f"{selected_text}\n{rendered}" if rendered else selected_text
     return rendered
 
 
-def _select_referenced_writes(older: Sequence[Any], task: str) -> list[str]:
-    """Older write blocks the latest task refers to (Stage 2, issue #82).
+def _select_written_files(older: Sequence[Any], task: str) -> list[tuple[str, str]]:
+    """Every conversation-written file's latest version, referenced-first
+    (Stage 2, issue #82).
 
     The client sends the full history every turn, so nothing is lost — only
-    windowed out. Selection is deterministic: a write is retrieved when the
-    task names its file, or names a class/def its body defines.
+    windowed out. Files are the workspace state generated code may import
+    (observed live: a build spuriously imported an un-referenced module), so
+    ALL of them are carried, ordered task-referenced first so cap pressure
+    drops the least relevant.
     """
     file_refs = {m.group(0).rsplit("/", 1)[-1] for m in _CTX_FILE_RE.finditer(task)}
     tokens = set(_CTX_TOKEN_RE.findall(task))
-    selected: list[str] = []
+    latest: dict[str, str] = {}
     for message in older:
         block = _render_write(message)
         if block is None:
             continue
         header = block.splitlines()[0]
+        path = header.split("[wrote ", 1)[1].split("]", 1)[0]
+        path = path.removesuffix(" (truncated)")
+        latest[path] = block  # later writes replace earlier versions
+
+    def referenced(item: tuple[str, str]) -> bool:
+        path, block = item
+        if path.rsplit("/", 1)[-1] in file_refs:
+            return True
         body = "\n".join(block.splitlines()[1:])
-        name_match = any(ref in header for ref in file_refs)
-        symbol_match = any(
+        return any(
             re.search(rf"\b(?:class|def)\s+{re.escape(t)}\b", body) for t in tokens
         )
-        if name_match or symbol_match:
-            selected.append(block)
-    return selected
+
+    items = list(latest.items())
+    return sorted(items, key=lambda item: (not referenced(item),))
 
 
 def _render_write(message: Any) -> str | None:

--- a/src/llm_orc/web/serving/serving_ensemble_caller.py
+++ b/src/llm_orc/web/serving/serving_ensemble_caller.py
@@ -119,7 +119,10 @@ def _render_context(messages: Sequence[Any]) -> str:
         rendered = rendered[cut + 1 :] if cut >= 0 else rendered
 
     task = _task_from(messages)
-    selected = _select_written_files(conversational[: -len(tail) or None], task)
+    # select over the FULL prior history, not just pre-tail messages: the
+    # tail char cap can slice a write off the front of the tail render, and
+    # the tail_paths dedup below already filters whatever survived in it
+    selected = _select_written_files(conversational, task)
     tail_paths = {
         line.split("[wrote ", 1)[1].split("]", 1)[0].removesuffix(" (truncated)")
         for line in rendered.splitlines()
@@ -149,7 +152,7 @@ def _whole_blocks_within_cap(blocks: list[str]) -> list[str]:
     return kept
 
 
-def _select_written_files(older: Sequence[Any], task: str) -> list[tuple[str, str]]:
+def _select_written_files(history: Sequence[Any], task: str) -> list[tuple[str, str]]:
     """Every conversation-written file's latest version, referenced-first
     (Stage 2, issue #82).
 
@@ -162,7 +165,7 @@ def _select_written_files(older: Sequence[Any], task: str) -> list[tuple[str, st
     file_refs = {m.group(0).rsplit("/", 1)[-1] for m in _CTX_FILE_RE.finditer(task)}
     tokens = set(_CTX_TOKEN_RE.findall(task))
     latest: dict[str, str] = {}
-    for message in older:
+    for message in history:
         block = _render_write(message)
         if block is None:
             continue

--- a/src/llm_orc/web/serving/serving_ensemble_caller.py
+++ b/src/llm_orc/web/serving/serving_ensemble_caller.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import uuid
 from collections.abc import AsyncIterator, Sequence
 from pathlib import Path
@@ -41,12 +42,18 @@ if TYPE_CHECKING:
 
 _WRITE_TOOL = "write"
 
-# Rung-1 conversation-context caps (memory design §Rung 1): bounded render,
-# flat per-turn cost regardless of session length.
+# Conversation-context caps (memory design §Rung 1/2'): bounded render,
+# flat per-turn cost regardless of session length. The tail carries recency;
+# referent selection retrieves older write blocks the task names from the
+# full wire history (the client sends it every turn — issue #82).
 _CTX_MAX_MESSAGES = 8
 _CTX_TEXT_CAP = 500
 _CTX_FILE_CAP = 2000
-_CTX_TOTAL_CAP = 4000
+_CTX_TAIL_CAP = 4000
+_CTX_SELECTED_CAP = 4000
+
+_CTX_FILE_RE = re.compile(r"\b[\w./-]+\.(?:py|js|ts|json|md|txt|ya?ml|sh|go|rs)\b")
+_CTX_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
 
 
 def _task_from(messages: Sequence[Any]) -> str:
@@ -97,19 +104,52 @@ def _render_context(messages: Sequence[Any]) -> str:
     conversational = [
         m for m in prior if getattr(m, "role", "") in ("user", "assistant")
     ]
-    for message in conversational[-_CTX_MAX_MESSAGES:]:
+    tail = conversational[-_CTX_MAX_MESSAGES:]
+    for message in tail:
         role = getattr(message, "role", "")
         line = _render_write(message) or _render_text(message, role)
         if line:
             lines.append(line)
     rendered = "\n".join(lines)
-    if len(rendered) > _CTX_TOTAL_CAP:
-        rendered = rendered[-_CTX_TOTAL_CAP:]
+    if len(rendered) > _CTX_TAIL_CAP:
+        rendered = rendered[-_CTX_TAIL_CAP:]
         # drop the decapitated first line — gather's workspace extraction is
         # line-anchored, and a partial '[wrote ...]' header corrupts it
         cut = rendered.find("\n")
         rendered = rendered[cut + 1 :] if cut >= 0 else rendered
+
+    task = _task_from(messages)
+    selected = _select_referenced_writes(conversational[: -len(tail) or None], task)
+    selected = [block for block in selected if block.splitlines()[0] not in rendered]
+    if selected:
+        selected_text = "\n".join(selected)[:_CTX_SELECTED_CAP]
+        rendered = f"{selected_text}\n{rendered}" if rendered else selected_text
     return rendered
+
+
+def _select_referenced_writes(older: Sequence[Any], task: str) -> list[str]:
+    """Older write blocks the latest task refers to (Stage 2, issue #82).
+
+    The client sends the full history every turn, so nothing is lost — only
+    windowed out. Selection is deterministic: a write is retrieved when the
+    task names its file, or names a class/def its body defines.
+    """
+    file_refs = {m.group(0).rsplit("/", 1)[-1] for m in _CTX_FILE_RE.finditer(task)}
+    tokens = set(_CTX_TOKEN_RE.findall(task))
+    selected: list[str] = []
+    for message in older:
+        block = _render_write(message)
+        if block is None:
+            continue
+        header = block.splitlines()[0]
+        body = "\n".join(block.splitlines()[1:])
+        name_match = any(ref in header for ref in file_refs)
+        symbol_match = any(
+            re.search(rf"\b(?:class|def)\s+{re.escape(t)}\b", body) for t in tokens
+        )
+        if name_match or symbol_match:
+            selected.append(block)
+    return selected
 
 
 def _render_write(message: Any) -> str | None:

--- a/tests/unit/serving/test_serving_accept_gather.py
+++ b/tests/unit/serving/test_serving_accept_gather.py
@@ -254,3 +254,41 @@ def test_executor_materializes_workspace_files_in_the_sandbox() -> None:
     }
     result = _executor_from_gather(gathered)
     assert result["tests_pass"] is True
+
+
+def test_executor_runs_unittest_class_style_tests() -> None:
+    """Seat models often emit unittest.TestCase classes; the runner must
+    collect and run those, not just top-level test_* functions (long-horizon
+    drive finding 2026-07-09: 'no test_* functions found')."""
+    gathered = {
+        "requirement": "is_even",
+        "code": "def is_even(n):\n    return n % 2 == 0",
+        "tests": (
+            "import unittest\n\n"
+            "class TestIsEven(unittest.TestCase):\n"
+            "    def test_even(self):\n"
+            "        self.assertTrue(is_even(4))\n"
+            "    def test_odd(self):\n"
+            "        self.assertFalse(is_even(3))\n"
+        ),
+        "workspace": {},
+    }
+    result = _executor_from_gather(gathered)
+    assert result["tests_pass"] is True
+    assert result["n_tests"] == 2
+
+
+def test_executor_reports_unittest_class_failures() -> None:
+    gathered = {
+        "requirement": "is_even",
+        "code": "def is_even(n):\n    return n % 2 == 1",  # wrong
+        "tests": (
+            "import unittest\n\n"
+            "class TestIsEven(unittest.TestCase):\n"
+            "    def test_even(self):\n"
+            "        self.assertTrue(is_even(4))\n"
+        ),
+        "workspace": {},
+    }
+    result = _executor_from_gather(gathered)
+    assert result["tests_pass"] is False

--- a/tests/unit/web/serving/test_serving_context_render.py
+++ b/tests/unit/web/serving/test_serving_context_render.py
@@ -238,6 +238,36 @@ def test_only_the_latest_version_of_a_rewritten_file_is_selected() -> None:
     assert "VERSION = 1" not in rendered
 
 
+def test_selected_cap_drops_whole_blocks_never_cuts_mid_block() -> None:
+    """Cap pressure on selected blocks must drop whole blocks (least relevant
+    last), never slice one mid-body — an intact '[wrote path]' header over a
+    silently cut body would make gather materialize a corrupted file."""
+
+    def body(name: str) -> str:
+        return ("x = 1\n" * 290) + f"# END {name}"
+
+    messages = [
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=(_write_call(f"f{i}.py", body(f"f{i}.py")),),
+        )
+        for i in (1, 2, 3)
+    ] + [
+        *_turnish(8),
+        ChatMessage(role="user", content="combine f1.py f2.py f3.py"),
+    ]
+
+    rendered = _render_context(messages)
+
+    included = [
+        name for name in ("f1.py", "f2.py", "f3.py") if f"[wrote {name}]" in rendered
+    ]
+    assert included  # cap leaves room for at least one block
+    for name in included:
+        assert f"# END {name}" in rendered
+
+
 def test_selected_write_is_not_duplicated_when_already_in_the_tail() -> None:
     messages = [
         ChatMessage(

--- a/tests/unit/web/serving/test_serving_context_render.py
+++ b/tests/unit/web/serving/test_serving_context_render.py
@@ -281,3 +281,34 @@ def test_selected_write_is_not_duplicated_when_already_in_the_tail() -> None:
     rendered = _render_context(messages)
 
     assert rendered.count("[wrote models.py]") == 1
+
+
+def test_write_truncated_out_of_the_tail_render_is_still_selected() -> None:
+    """A write inside the 8-message tail window can still be sliced off the
+    FRONT of the tail render by the tail char cap — it must then be selected
+    like any out-of-tail write, not lost entirely."""
+    body = "class Task:\n" + ("    x = 1\n" * 100)
+    messages = [
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=(_write_call("models.py", body),),
+        ),
+        # 7 long text messages: with the write these fill the tail window and
+        # overflow the tail char cap, slicing the write off the front
+        *[
+            ChatMessage(role="user", content="p" * 600),
+            ChatMessage(role="assistant", content="q" * 600),
+            ChatMessage(role="user", content="p" * 600),
+            ChatMessage(role="assistant", content="q" * 600),
+            ChatMessage(role="user", content="p" * 600),
+            ChatMessage(role="assistant", content="q" * 600),
+            ChatMessage(role="user", content="p" * 600),
+        ],
+        ChatMessage(role="user", content="Add a field to models.py"),
+    ]
+
+    rendered = _render_context(messages)
+
+    assert rendered.count("[wrote models.py]") == 1
+    assert "class Task" in rendered

--- a/tests/unit/web/serving/test_serving_context_render.py
+++ b/tests/unit/web/serving/test_serving_context_render.py
@@ -144,3 +144,84 @@ def test_truncation_lands_on_a_line_boundary() -> None:
     for line in rendered.splitlines():
         if "[wrote" in line:
             assert line.startswith("assistant: [wrote ")
+
+
+def _turnish(n: int) -> list[ChatMessage]:
+    """n filler turns (user + assistant) to push earlier content out of
+    the recency tail."""
+    out: list[ChatMessage] = []
+    for i in range(n):
+        out.append(ChatMessage(role="user", content=f"filler question {i}"))
+        out.append(ChatMessage(role="assistant", content=f"filler answer {i}"))
+    return out
+
+
+def test_out_of_tail_write_is_selected_when_the_task_names_its_file() -> None:
+    """Stage 2 (issue #82): the client sends the FULL history, so a write
+    older than the recency tail is retrievable — when the latest task names
+    its file, the write block is selected back into the context."""
+    messages = [
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=(_write_call("models.py", "class Task:\n    pass"),),
+        ),
+        *_turnish(8),
+        ChatMessage(
+            role="user", content="Create formatting.py; import Task from models.py"
+        ),
+    ]
+
+    rendered = _render_context(messages)
+
+    assert "[wrote models.py]" in rendered
+    assert "class Task" in rendered
+
+
+def test_out_of_tail_write_is_selected_by_symbol_match() -> None:
+    """A task naming a class/function defined in an old write selects that
+    write even without naming the file."""
+    messages = [
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=(_write_call("storage.py", "class TaskStore:\n    pass"),),
+        ),
+        *_turnish(8),
+        ChatMessage(role="user", content="Add a clear() method to TaskStore"),
+    ]
+
+    rendered = _render_context(messages)
+
+    assert "[wrote storage.py]" in rendered
+
+
+def test_unrelated_old_write_is_not_selected() -> None:
+    messages = [
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=(_write_call("unrelated.py", "def nothing():\n    pass"),),
+        ),
+        *_turnish(8),
+        ChatMessage(role="user", content="explain what a decorator is"),
+    ]
+
+    rendered = _render_context(messages)
+
+    assert "[wrote unrelated.py]" not in rendered
+
+
+def test_selected_write_is_not_duplicated_when_already_in_the_tail() -> None:
+    messages = [
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=(_write_call("models.py", "class Task:\n    pass"),),
+        ),
+        ChatMessage(role="user", content="Add a field to models.py"),
+    ]
+
+    rendered = _render_context(messages)
+
+    assert rendered.count("[wrote models.py]") == 1

--- a/tests/unit/web/serving/test_serving_context_render.py
+++ b/tests/unit/web/serving/test_serving_context_render.py
@@ -196,7 +196,10 @@ def test_out_of_tail_write_is_selected_by_symbol_match() -> None:
     assert "[wrote storage.py]" in rendered
 
 
-def test_unrelated_old_write_is_not_selected() -> None:
+def test_all_written_files_are_carried_as_workspace_state() -> None:
+    """Generated code may import ANY conversation file (observed live:
+    formatting.py spuriously imported storage), so every written file's
+    latest version is carried, not just task-referenced ones."""
     messages = [
         ChatMessage(
             role="assistant",
@@ -209,7 +212,30 @@ def test_unrelated_old_write_is_not_selected() -> None:
 
     rendered = _render_context(messages)
 
-    assert "[wrote unrelated.py]" not in rendered
+    assert "[wrote unrelated.py]" in rendered
+
+
+def test_only_the_latest_version_of_a_rewritten_file_is_selected() -> None:
+    messages = [
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=(_write_call("mod.py", "VERSION = 1"),),
+        ),
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=(_write_call("mod.py", "VERSION = 2"),),
+        ),
+        *_turnish(8),
+        ChatMessage(role="user", content="add a helper to mod.py"),
+    ]
+
+    rendered = _render_context(messages)
+
+    assert rendered.count("[wrote mod.py]") == 1
+    assert "VERSION = 2" in rendered
+    assert "VERSION = 1" not in rendered
 
 
 def test_selected_write_is_not_duplicated_when_already_in_the_tail() -> None:

--- a/tests/unit/web/test_serving_ensemble_endpoint.py
+++ b/tests/unit/web/test_serving_ensemble_endpoint.py
@@ -322,3 +322,39 @@ def test_explain_turn_returns_prose_not_a_tool_call(
     content = choice["message"]["content"]
     assert content
     assert "foo.py" in content
+
+
+def test_wire_log_records_message_shape_when_enabled(
+    serving_project: Path,
+    serving_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """LLM_ORC_SERVE_WIRE_LOG=<path> appends one JSONL row per request with
+    the message shape (roles, content lengths, rolling prefix hashes) — the
+    issue #82 entry-gate instrumentation for observing client-side
+    compaction on the wire. Content itself is never logged."""
+    wire_log = tmp_path / "wire.jsonl"
+    monkeypatch.setenv("LLM_ORC_SERVE_WIRE_LOG", str(wire_log))
+
+    resp = serving_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "ensemble-agent",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "Hi!"},
+                {"role": "user", "content": "explain what foo.py does"},
+            ],
+            "tools": [_WRITE_TOOL],
+        },
+    )
+
+    assert resp.status_code == 200
+    row = json.loads(wire_log.read_text().strip().splitlines()[-1])
+    assert row["message_count"] == 3
+    assert [m["role"] for m in row["messages"]] == ["user", "assistant", "user"]
+    assert row["messages"][0]["content_len"] == len("hello")
+    # rolling prefix hash chain: same prefix -> same hashes across requests
+    assert len(row["messages"][0]["prefix_hash"]) == 12
+    assert "hello" not in wire_log.read_text()


### PR DESCRIPTION
The issue #82 entry gate ran as a real 9-turn multi-file OpenCode session (todo app: models, storage, tests, formatting, cli) with new wire-shape instrumentation.

**Wire observation (entry gate):** OpenCode's wire is append-only with stable prefix hashes and NO compaction through 30+ messages. Conclusion: the lossless record is already on the wire, so stage 2's core ships as stateless deterministic selection over the full client-sent history; a server-side record + divergence classifier waits until client compaction is actually observed.

**Shipped:**
- LLM_ORC_SERVE_WIRE_LOG: per-request message-shape JSONL (roles, lengths, rolling prefix hashes; never content)
- Context = recency tail + EVERY conversation-written file's latest version (task-referenced first under an independent cap) — live finding: generated code imports files the task never named
- The accept-gate runner collects unittest.TestCase classes ('no test_* functions found' was rejecting good rounds)

**Long-horizon result:** 8/9 turns green including a three-module cross-file build at turn 6 and a precise answer about turn-1 content at turn 8. The one failure (cli.py integration) is a newly-characterized class — independently resampled tests and code disagree on spec-free choices — filed separately with the TDD-loop fix direction.

2534 tests, mypy strict + ruff clean.