### PR TITLE
TDD retry loop: round 2 holds round 1's tests as the spec (#100)

### DIFF
--- a/.llm-orc/ensembles/agentic-serving/build-code-round.yaml
+++ b/.llm-orc/ensembles/agentic-serving/build-code-round.yaml
@@ -32,4 +32,5 @@ agents:
 
   - name: envelope
     script: scripts/agentic_serving/build_gated_envelope.py
-    depends_on: [code_writer, executor, accept_gate]
+    # gather is wired in so diagnostics.held_round marks this round's mode
+    depends_on: [code_writer, executor, accept_gate, gather]

--- a/.llm-orc/ensembles/agentic-serving/build-code-round.yaml
+++ b/.llm-orc/ensembles/agentic-serving/build-code-round.yaml
@@ -1,0 +1,35 @@
+name: build-code-round
+description: |
+  The held TDD retry round (issue #100): round 1's tests — collected, run,
+  and judged adequate — ARE the spec, so this round regenerates only the
+  code against them (TDD's actual loop; both sides resampling made
+  convergence luck on spec-free choices). gather reads the tests from the
+  carry's HELD TESTS sentinel block (no test_writer seat); accept_gate
+  carries round 1's adequacy verdict from gather's held flag (no judge
+  seat — re-judging identical tests only risks a stochastic flip, #84);
+  the executor stays the live deterministic ground truth. Strengthens
+  ADR-048 criteria-primacy: round 1's tests become round 2's concrete
+  criteria.
+
+# Not registry-facing — no topaz_skill and no serves; it is resolved only
+# by build-round's dispatch.
+
+agents:
+  - name: code_writer
+    ensemble: code-generator
+
+  - name: gather
+    script: scripts/agentic_serving/accept_gather.py
+    depends_on: [code_writer]
+
+  - name: executor
+    script: scripts/agentic_serving/accept_executor.py
+    depends_on: [gather]
+
+  - name: accept_gate
+    script: scripts/agentic_serving/accept_gate.py
+    depends_on: [executor, gather]
+
+  - name: envelope
+    script: scripts/agentic_serving/build_gated_envelope.py
+    depends_on: [code_writer, executor, accept_gate]

--- a/.llm-orc/ensembles/agentic-serving/build-gated.yaml
+++ b/.llm-orc/ensembles/agentic-serving/build-gated.yaml
@@ -1,16 +1,19 @@
 name: build-gated
 description: |
-  The gated build seat with a bounded retry round (issue #89; ADR-048 §5
-  round budget). The engine's loop primitive re-runs build-gated-round —
-  test-writer -> code-writer -> executor -> judge -> accept gate -> envelope —
-  until the accept verdict holds or the bound trips. On a reject, the round's
-  envelope composes diagnostics.retry_input (the original turn + the executor's
-  failure report); the loop carries it as the next round's input, so one flaky
-  generated assertion no longer kills the turn (the dominant failure class,
-  confirmed across seat tiers in the 2026-07-08 A/B). unwrap peels the loop
-  wrapper back to the bare ADR-024 envelope so the serving marshal and the
-  seat contract are unchanged. Deterministic control: closed bound, predicate
-  over the deterministic verdict, no model judgment in the loop decision.
+  The gated build seat with a bounded TDD retry round (issues #89, #100;
+  ADR-048 §5 round budget). The engine's loop primitive re-runs build-round —
+  a deterministic router over the fresh TDD round (test-writer -> code-writer
+  -> executor -> judge -> accept gate -> envelope) and the held code-only
+  round — until the accept verdict holds or the bound trips. On a reject,
+  the round's envelope composes diagnostics.retry_input (the original turn +
+  the executor's failure report, plus the round's tests under the HELD TESTS
+  sentinel when they collected and were judged adequate); the loop carries it
+  as the next round's input, so one flaky assertion no longer kills the turn
+  and round 2 no longer resamples both sides of a spec-free disagreement
+  (TDD's actual loop: the tests hold, only the code moves). unwrap peels the
+  loop wrapper back to the bare ADR-024 envelope so the serving marshal and
+  the seat contract are unchanged. Deterministic control: closed bound,
+  predicates over deterministic verdicts, no model judgment in loop or route.
 
 topaz_skill: code_generation
 serves: code-seat
@@ -19,7 +22,7 @@ agents:
   - name: round
     timeout_seconds: 660
     loop:
-      body: build-gated-round
+      body: build-round
       until: "${diagnostics.accept}"
       max_iterations: 2
       carry: "${diagnostics.retry_input}"

--- a/.llm-orc/ensembles/agentic-serving/build-round.yaml
+++ b/.llm-orc/ensembles/agentic-serving/build-round.yaml
@@ -1,0 +1,31 @@
+name: build-round
+description: |
+  The retry loop's body (issue #100): a deterministic router over the two
+  round shapes. route reads the loop-carried input — round 1 is the bare
+  turn (fresh TDD round); a rejected round whose tests collected and were
+  judged adequate carries them under the HELD TESTS sentinel, and the held
+  round holds those tests as the spec and regenerates only the code.
+  dispatch fills the chosen round; unwrap peels the dispatch wrapper so the
+  loop's until/carry predicates keep reading the bare ADR-024 round
+  envelope. Deterministic control: the route is a substring check on a
+  sentinel only the envelope composes — no model judgment in the decision.
+
+# Not registry-facing — no topaz_skill (it must not register as a capability
+# part) and no serves (it is not a catalog shape); it is resolved only by
+# build-gated's loop node.
+
+agents:
+  - name: route
+    script: scripts/agentic_serving/route_round.py
+
+  - name: dispatch
+    dispatch: "${route.target}"
+    input_key: round_input
+    depends_on: [route]
+    # one full gated round (3 model calls on the 32GB rig) needs headroom
+    # past the 300s default; the outer loop node bounds the total
+    timeout_seconds: 600
+
+  - name: unwrap
+    script: scripts/agentic_serving/dispatch_unwrap.py
+    depends_on: [dispatch]

--- a/.llm-orc/ensembles/agentic-serving/test-writer.yaml
+++ b/.llm-orc/ensembles/agentic-serving/test-writer.yaml
@@ -38,5 +38,9 @@ agents:
       - Cover the normal cases AND any specific rule or edge the task names.
       - Do NOT write the implementation. Tests only.
       - Do NOT import the module under test; assume the function is in scope.
+      - Instantiate objects and exercise real behavior. NEVER write
+        reflection-style checks — no hasattr, callable, or isinstance
+        tests. They pass wrong implementations and fail right ones (a
+        dataclass field with no default is not a class attribute).
       - Output ONLY the test code: a series of `def test_*():` functions, with
         no prose and no markdown code fences.

--- a/.llm-orc/ensembles/build-code-round.yaml
+++ b/.llm-orc/ensembles/build-code-round.yaml
@@ -1,0 +1,1 @@
+agentic-serving/build-code-round.yaml

--- a/.llm-orc/ensembles/build-round.yaml
+++ b/.llm-orc/ensembles/build-round.yaml
@@ -1,0 +1,1 @@
+agentic-serving/build-round.yaml

--- a/.llm-orc/scripts/agentic_serving/_helpers.py
+++ b/.llm-orc/scripts/agentic_serving/_helpers.py
@@ -18,6 +18,12 @@ from typing import Any
 # Fences tagged with a shell-ish language are usage examples, not code.
 SHELL_LANGS = {"bash", "sh", "shell", "console", "zsh", "text"}
 
+# The TDD retry sentinel (issue #100): a rejected round whose tests collected
+# and were judged adequate carries them under this marker; route dispatches
+# the held round on it, and gather reads the tests back out. One constant —
+# the envelope writes it, route and gather read it.
+HELD_TESTS_MARKER = "[HELD TESTS: round 1 spec; regenerate ONLY the code]"
+
 _FENCE_RE = re.compile(r"```([a-zA-Z0-9_+-]*)\n(.*?)```", re.DOTALL)
 
 

--- a/.llm-orc/scripts/agentic_serving/_helpers.py
+++ b/.llm-orc/scripts/agentic_serving/_helpers.py
@@ -11,6 +11,7 @@ different code than emit shipped.
 
 from __future__ import annotations
 
+import ast
 import json
 import re
 from typing import Any
@@ -76,18 +77,47 @@ def terminal(text: str) -> str:
     return current
 
 
-def extract_code(text: str) -> str:
+def extract_code(text: str, *, drop_test_blocks: bool = False) -> str:
     """The code deliverable from a (possibly chatty) seat response.
 
     Non-shell fenced blocks joined; falls back to all fences, then to the
     raw text. The ONE set of semantics for the gate, the envelope, and
     emit — divergent copies meant the gate could approve code that was not
     the code shipped.
+
+    ``drop_test_blocks`` is for the CODE consumers only: seat models
+    sometimes emit the code and a copy of the tests as two fences, and
+    joining them ships a file with the test suite embedded. Pure-test
+    blocks are dropped when a non-test block exists; the tests extraction
+    never sets this (test blocks are its point).
     """
     tagged = _FENCE_RE.findall(text)
     blocks = [
         body for lang, body in tagged if lang.lower() not in SHELL_LANGS
     ] or [body for _, body in tagged]
+    if drop_test_blocks and len(blocks) > 1:
+        non_test = [block for block in blocks if not _is_pure_test_block(block)]
+        blocks = non_test or blocks
     if blocks:
         return "\n".join(block.strip() for block in blocks)
     return text.strip()
+
+
+def _is_pure_test_block(block: str) -> bool:
+    """A parsed block whose top-level defs/classes are all test-named
+    (imports and docstrings allowed). Non-parsing blocks are kept."""
+    try:
+        tree = ast.parse(block)
+    except SyntaxError:
+        return False
+    named = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+    ]
+    if not named:
+        return False
+    return all(
+        node.name.startswith("test_") or node.name.startswith("Test")
+        for node in named
+    )

--- a/.llm-orc/scripts/agentic_serving/accept_gate.py
+++ b/.llm-orc/scripts/agentic_serving/accept_gate.py
@@ -68,12 +68,21 @@ def main() -> None:
     tests_adequate = _extract_bool(_dep_response(deps, "judge"), "tests_adequate")
 
     reasons: list[str] = []
+    carried = False
     if tests_pass is None:
         tests_pass = False
         reasons.append("executor verdict unreadable")
     if tests_adequate is None:
-        tests_adequate = False
-        reasons.append("judge verdict unreadable")
+        # held round (issue #100): no judge seat — the held path only fires
+        # when round 1's judge passed these exact tests, so the verdict
+        # carries deterministically; the executor stays the live gate.
+        # No judge AND no held flag is a miswired shape, not a free pass.
+        if _extract_bool(_dep_response(deps, "gather"), "held"):
+            tests_adequate = True
+            carried = True
+        else:
+            tests_adequate = False
+            reasons.append("judge verdict unreadable")
 
     accept = bool(tests_pass and tests_adequate)
     if not accept and not reasons:
@@ -82,7 +91,12 @@ def main() -> None:
         if not tests_adequate:
             reasons.append("tests inadequate to verify the requirement")
 
-    reason = "; ".join(reasons) if reasons else "tests pass and are adequate"
+    if reasons:
+        reason = "; ".join(reasons)
+    elif carried:
+        reason = "tests pass; adequacy carried from round 1"
+    else:
+        reason = "tests pass and are adequate"
     print(
         json.dumps(
             {

--- a/.llm-orc/scripts/agentic_serving/accept_gather.py
+++ b/.llm-orc/scripts/agentic_serving/accept_gather.py
@@ -18,6 +18,7 @@ import re
 import sys
 
 import _helpers
+from _helpers import HELD_TESTS_MARKER as _HELD_MARKER
 from _helpers import payload as _payload
 from _helpers import response as _response
 from _helpers import terminal as _terminal
@@ -147,7 +148,18 @@ def main() -> None:
     if not isinstance(deps, dict):
         deps = {}
 
-    tests = _extract_tests(_terminal(_response(deps.get("test_writer", {}))))
+    # held round (issue #100): no test_writer seat — the carry's sentinel
+    # block IS the spec; strip it from the requirement the verifiers echo.
+    # A fresh round with test_writer output never takes this path, so a
+    # sentinel in user text worst-cases into a reject, never a wrong accept.
+    tests_terminal = _terminal(_response(deps.get("test_writer", {})))
+    held = not tests_terminal.strip() and _HELD_MARKER in requirement
+    if held:
+        requirement, _, held_block = requirement.partition(_HELD_MARKER)
+        requirement = requirement.strip()
+        tests = _extract_tests(held_block)
+    else:
+        tests = _extract_tests(tests_terminal)
     code = _extract_code(_terminal(_response(deps.get("code_writer", {}))))
     tests = _inject_workspace_imports(tests, workspace)
     code = _inject_workspace_imports(code, workspace)
@@ -161,6 +173,7 @@ def main() -> None:
                 "requirement": requirement,
                 "code": code,
                 "tests": tests,
+                "held": held,
                 "workspace": workspace,
                 "target_file": target_file,
             }

--- a/.llm-orc/scripts/agentic_serving/accept_gather.py
+++ b/.llm-orc/scripts/agentic_serving/accept_gather.py
@@ -50,7 +50,7 @@ def _trim_to_parse(code: str, max_drops: int = 10) -> str:
 
 
 def _extract_code(text: str) -> str:
-    return _trim_to_parse(_helpers.extract_code(text))
+    return _trim_to_parse(_helpers.extract_code(text, drop_test_blocks=True))
 
 
 def _extract_tests(text: str) -> str:

--- a/.llm-orc/scripts/agentic_serving/build_gated_envelope.py
+++ b/.llm-orc/scripts/agentic_serving/build_gated_envelope.py
@@ -63,7 +63,9 @@ def _held_round(deps: dict[str, object]) -> bool:
 def main() -> None:
     payload = _payload(sys.stdin.read().strip())
     deps = _deps(payload)
-    code = _extract_code(_terminal(_response(deps.get("code_writer", {}))))
+    code = _extract_code(
+        _terminal(_response(deps.get("code_writer", {}))), drop_test_blocks=True
+    )
     verdict = _verdict(deps)
     summary = code.splitlines()[0][:80] if code.strip() else "code deliverable"
 

--- a/.llm-orc/scripts/agentic_serving/build_gated_envelope.py
+++ b/.llm-orc/scripts/agentic_serving/build_gated_envelope.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import sys
 
+from _helpers import HELD_TESTS_MARKER as _HELD_MARKER
 from _helpers import deps as _deps
 from _helpers import extract_code as _extract_code
 from _helpers import payload as _payload
@@ -27,12 +28,12 @@ from _helpers import terminal as _terminal
 
 
 
-def _executor_report(deps: dict[str, object]) -> str:
+def _executor_result(deps: dict[str, object]) -> dict[str, object]:
     try:
         parsed = json.loads(_response(deps.get("executor", {})))
     except (json.JSONDecodeError, TypeError):
-        return ""
-    return str(parsed.get("report", "")) if isinstance(parsed, dict) else ""
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 
@@ -65,13 +66,30 @@ def main() -> None:
     if not diagnostics["accept"]:
         # the bounded retry round's carry REPLACES the next iteration's
         # input (loop primitive semantics), so compose turn + evidence here
-        report = _executor_report(deps)
-        diagnostics["retry_input"] = (
-            f"{payload.get('input_data', '')}\n\n"
-            f"[Previous round rejected: {diagnostics['accept_reason']}."
-            f" Executor report: {report}."
-            f" Regenerate, fixing the failing tests or wrong expectations.]"
-        )
+        executor = _executor_result(deps)
+        report = str(executor.get("report", ""))
+        tests = str(executor.get("tests", ""))
+        n_tests = int(executor.get("n_tests", 0) or 0)
+        held = bool(diagnostics["tests_adequate"] and n_tests > 0 and tests.strip())
+        if held:
+            # TDD retry (issue #100): the round's tests collected, ran, and
+            # were judged adequate — they ARE the spec; round 2 holds them
+            # fixed and regenerates only the code (route dispatches on the
+            # marker to the held round)
+            diagnostics["retry_input"] = (
+                f"{payload.get('input_data', '')}\n\n"
+                f"[Previous round rejected: {diagnostics['accept_reason']}."
+                f" Executor report: {report}."
+                f" The tests below are the spec; write code that passes them.]\n\n"
+                f"{_HELD_MARKER}\n```python\n{tests}\n```"
+            )
+        else:
+            diagnostics["retry_input"] = (
+                f"{payload.get('input_data', '')}\n\n"
+                f"[Previous round rejected: {diagnostics['accept_reason']}."
+                f" Executor report: {report}."
+                f" Regenerate, fixing the failing tests or wrong expectations.]"
+            )
 
     envelope = {
         "status": "success",

--- a/.llm-orc/scripts/agentic_serving/build_gated_envelope.py
+++ b/.llm-orc/scripts/agentic_serving/build_gated_envelope.py
@@ -49,6 +49,17 @@ def _verdict(deps: dict[str, object]) -> dict[str, object]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def _held_round(deps: dict[str, object]) -> bool:
+    """Whether this round ran held (build-code-round wires gather in as an
+    envelope dep; the fresh round has no gather dep here) — the round's mode
+    is only knowable live from the envelope diagnostics."""
+    try:
+        parsed = json.loads(_response(deps.get("gather", {})))
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return bool(parsed.get("held", False)) if isinstance(parsed, dict) else False
+
+
 def main() -> None:
     payload = _payload(sys.stdin.read().strip())
     deps = _deps(payload)
@@ -62,6 +73,7 @@ def main() -> None:
         "accept_reason": str(verdict.get("reason", "")),
         "tests_pass": bool(verdict.get("tests_pass", False)),
         "tests_adequate": bool(verdict.get("tests_adequate", False)),
+        "held_round": _held_round(deps),
     }
     if not diagnostics["accept"]:
         # the bounded retry round's carry REPLACES the next iteration's

--- a/.llm-orc/scripts/agentic_serving/dispatch_unwrap.py
+++ b/.llm-orc/scripts/agentic_serving/dispatch_unwrap.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Peel a dispatch node's wrapper back to the child's terminal envelope.
+
+A ``dispatch:`` node responds with the child ensemble's full result dict
+(``{"ensemble": ..., "deliverable": <terminal response>, "results": ...}``).
+The retry loop's ``until``/``carry`` predicates and the serving marshal
+expect the bare ADR-024 envelope the round's terminal emits — this node
+restores that contract deterministically (the dispatch sibling of
+``loop_unwrap``).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from _helpers import deps as _deps
+from _helpers import payload as _payload
+from _helpers import response as _response
+
+
+def main() -> None:
+    payload = _payload(sys.stdin.read().strip())
+    envelope: dict[str, object] = {}
+    for dep in _deps(payload).values():
+        try:
+            wrapper = json.loads(_response(dep))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(wrapper, dict):
+            continue
+        deliverable = wrapper.get("deliverable")
+        if isinstance(deliverable, str):
+            try:
+                parsed = json.loads(deliverable)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if isinstance(parsed, dict):
+                envelope = parsed
+                break
+    print(json.dumps(envelope))
+
+
+if __name__ == "__main__":
+    main()

--- a/.llm-orc/scripts/agentic_serving/emit_envelope.py
+++ b/.llm-orc/scripts/agentic_serving/emit_envelope.py
@@ -40,7 +40,7 @@ def main() -> None:
     deps_map = __payload(sys.stdin.read().strip()).get("dependencies", {})
     deps = deps_map if isinstance(deps_map, dict) else {}
     generated = _terminal(_response(deps.get("generate", {})))
-    code = _extract_code(generated)
+    code = _extract_code(generated, drop_test_blocks=True)
     summary = code.splitlines()[0][:80] if code.strip() else "code deliverable"
 
     envelope = {

--- a/.llm-orc/scripts/agentic_serving/route_round.py
+++ b/.llm-orc/scripts/agentic_serving/route_round.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""build-round router — pick the round shape from the carried input (issue #100).
+
+Head node of the retry loop's body. Round 1's input is the turn itself; a
+rejected round whose tests collected and were judged adequate carries them
+under the HELD TESTS sentinel (composed by build_gated_envelope). The route
+is deterministic: sentinel present -> the code-only held round (tests are
+the spec), else the full fresh TDD round. A sentinel in user-authored turn
+text worst-cases into a held round the gate rejects — degraded, never a
+wrong accept.
+
+Emits JSON: {target, round_input}
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from _helpers import HELD_TESTS_MARKER as _HELD_MARKER
+from _helpers import payload as _payload
+
+
+def main() -> None:
+    payload = _payload(sys.stdin.read().strip())
+    round_input = ""
+    for key in ("input_data", "input"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            round_input = value
+            break
+    target = (
+        "build-code-round" if _HELD_MARKER in round_input else "build-gated-round"
+    )
+    print(json.dumps({"target": target, "round_input": round_input}))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/plans/2026-07-09-tdd-retry-loop-design.md
+++ b/docs/plans/2026-07-09-tdd-retry-loop-design.md
@@ -1,0 +1,82 @@
+# TDD retry loop — held tests on the accept-gate retry round (#100)
+
+**Problem (long-horizon drive 2026-07-09, todoapp turn 7):** on a gate
+reject, both `test_writer` and `code_writer` resample per round, so the
+two sides disagree on spec-free choices (exact strings, remove-nonexistent
+semantics) and convergence is luck. TDD's actual loop holds the tests
+fixed and moves only the code.
+
+**Design (approved 2026-07-09):** dispatched dual shape — the loop body
+becomes a deterministic router; pure composition, no engine changes.
+
+```
+build-gated
+  round (loop:, until ${diagnostics.accept}, max 2, carry ${diagnostics.retry_input})
+    └─ build-round (router)
+         route ──> dispatch ──┬─> build-gated-round   (fresh TDD round, untouched)
+                              └─> build-code-round    (held tests, code only)
+         └─> unwrap passthrough (loop keeps reading the bare round envelope)
+```
+
+## Retry-mode decision (deterministic, in the round envelope)
+
+On reject, `build_gated_envelope.py` picks the carry:
+
+- executor `n_tests > 0` (tests collected and ran) **and** judge
+  `tests_adequate` → **held mode**: `retry_input` = original turn +
+  executor failure report + the round's tests (echoed by the executor)
+  under a `[HELD TESTS]` sentinel block.
+- otherwise (collection failure or inadequate tests) → today's fresh
+  `retry_input`, unchanged.
+
+`route` detects the sentinel: held → `build-code-round`, else
+`build-gated-round`. Round 1 never carries the sentinel, so it is always
+fresh. The sentinel constant is defined once in `_helpers.py` (envelope
+writes it, route and gather read it).
+
+## build-code-round
+
+`code_writer → gather → executor → accept_gate → envelope` — no
+`test_writer`, no `judge`.
+
+- `accept_gather.py`: when the `test_writer` dep is absent, extract tests
+  from the sentinel block and strip it from the echoed requirement;
+  emit `held: true`. Context/workspace extraction is untouched (the carry
+  preserves the original turn text).
+- `accept_gate.py`: when the `judge` dep is absent and gather marked the
+  round held, `tests_adequate` carries as true ("adequacy carried from
+  round 1") — the held path only fires when round 1's judge already
+  passed the tests, re-judging identical tests only risks a stochastic
+  flip (#84), and the executor stays the live ground truth.
+- `envelope`: unchanged behavior (a second reject exits the loop honestly
+  at the bound).
+
+Neither new shape is registry-facing (no `topaz_skill`, no `serves`),
+like `build-gated-round`.
+
+## Bounds, failure, depth
+
+- `max_iterations: 2` stays: round 1 fresh, round 2 held (or fresh, per
+  the decision above).
+- A turn whose text contains the sentinel worst-cases into a held round
+  whose gate rejects — degraded, never wrong-accept.
+- Nesting: serving → build-gated → build-round → build-\*-round → seats
+  = depth 4 of 5.
+
+## Validation
+
+- Unit tests per modified script: envelope retry-mode decision, gather
+  sentinel extraction + requirement stripping, gate carried adequacy,
+  route.
+- Ensemble-level: rejected round 1 carries held tests; round 2 dispatches
+  to `build-code-round` and accepts.
+- Live exit gate (roadmap): rerun the real-OpenCode battery — the
+  cli.py-class integration turn passes AND the non-code turns (explain,
+  recall) stay green; parity is the whole task surface, not just build.
+
+## Note beyond code
+
+"Hold the verified half fixed, regenerate the dependent half" is a
+general orchestration pattern (criteria-primacy, ADR-048): the same shape
+applies to non-code seats later (e.g. held acceptance criteria for prose
+revision). This item implements it for the build seat only.

--- a/docs/serving-roadmap.md
+++ b/docs/serving-roadmap.md
@@ -37,8 +37,11 @@ parity-percentage arm (Haiku 4.5 / Sonnet 5 behind OpenCode as baseline).
 ## Current state (2026-07-09)
 
 Released: **v0.18.0** (agentic serving) and **v0.18.1** (review-debt sweep).
-Pending review: **PR #99** — Stage 2 core (wire observation + full-history
-selection + gate-runner TestCase support).
+Merged: **PR #99** — Stage 2 core (wire observation + full-history
+selection + gate-runner TestCase support), released as **v0.18.2**.
+In flight: the `tdd-retry-loop` branch — #100 shipped plus the 2026-07-09
+live-diagnosis fixes (reject-noise filter, deliverable test-fence pollution,
+reflection-test prompt ban, `held_round` + trace-depth observability).
 
 Shipped capability: build (accept-gated, bounded retry), explain,
 edit-existing (conversation-written files), within-session memory with
@@ -56,17 +59,26 @@ Key empirical facts the next work builds on:
 - The dominant hard-turn failure is now **spec-freedom divergence**:
   independently resampled tests and code disagree on choices the spec
   leaves open.
+- **Round-1 test quality gates everything** (2026-07-09 live diagnosis):
+  the held TDD retry fires only when round 1's tests collected AND were
+  judged adequate, so judge adequacy (#84) and test-writer quality (#98)
+  directly bound the retry's live win-rate. The 8b seat's reflection-test
+  mode (hasattr/callable — fails right code, passes wrong code) was banned
+  in the seat prompt; failures moved to ordinary code/test disagreements.
 
 ## The path, in order of leverage
 
-### 1. TDD retry loop (#100) — next up
+### 1. TDD retry loop (#100) — SHIPPED (tdd-retry-loop branch)
 
-On a gate reject where round 1's tests loaded and ran, hold those tests
-fixed as the spec and regenerate only the code (regenerate tests only when
-they failed to collect). Directly attacks the spec-freedom failure (the one
-lost turn in the 9-turn battery) and strengthens ADR-048's
-criteria-primacy: round 1's tests become round 2's concrete criteria.
-Exit gate: the cli.py-style integration turn passes; ladder ≥ 9/9.
+The loop body is now a deterministic router: a reject whose tests collected
+and were judged adequate carries them under a HELD TESTS sentinel, and
+round 2 dispatches to `build-code-round` — code only, adequacy carried,
+executor as the live gate. Proven hermetically (the real graph through the
+real engine) and live (route → held round → qwen3:8b regenerated code →
+accept, `held_round: true`). Remaining exit gate: a full clean-session
+ladder rerun once the #84/#98 bottleneck stops masking it — live diagnosis
+showed the held path's entry condition is judge adequacy on round 1, which
+moves the gate integrity pair up in leverage.
 
 ### 2. Client execution surface (#83)
 
@@ -77,14 +89,17 @@ the tool-mapping step (resolve emit outcomes against the client's
 advertised tools instead of the hardcoded `write`). Closes run-tests and
 pre-existing-file editing — the two biggest remaining parity holes.
 
-### 3. Gate integrity pair (#98, #84)
+### 3. Gate integrity pair (#98, #84) — raised in leverage
 
 #98: test-writing turns validate a shadowed composite in the shared exec
 namespace — route "write tests" to a dedicated shape (the deliverable IS
 the test file, run against the materialized workspace alone). #84: measure
 judge false-reject rate on fixtures (with retries wired, judge conservatism
 is the visible bottleneck on hard turns) and revisit ADR-048 §5's
-AND-vs-weighted composition with data.
+AND-vs-weighted composition with data. The 2026-07-09 diagnosis makes this
+pair the TDD loop's gatekeeper: round-1 adequacy is the held path's entry
+condition, so measuring and tuning it is what converts #100 from
+mechanism-proven to ladder-visible.
 
 ### 4. Shapes and seat tiering
 
@@ -122,8 +137,9 @@ removal).
 
 ## Issue index
 
-Path: #100 TDD retry · #83 client execution · #98 test-shape gate ·
-#84 judge measurement · #82 memory remainder · #90 llama.cpp ·
-#85 sandbox hardening · #93/#95 remainders.
+Path: #98/#84 gate integrity (raised) · #83 client execution ·
+#82 memory remainder · #90 llama.cpp · #85 sandbox hardening ·
+#93/#95 remainders.
 Shipped: #87 #88 #89 (v0.18.0) · #86 #91 #92 #94 #96 (v0.18.1) ·
-#82-core + gate-runner TestCase support (PR #99).
+#82-core + gate-runner TestCase support (v0.18.2, PR #99) ·
+#100 TDD retry + live-diagnosis fixes (tdd-retry-loop branch).

--- a/src/llm_orc/web/serving/serving_ensemble_caller.py
+++ b/src/llm_orc/web/serving/serving_ensemble_caller.py
@@ -55,6 +55,11 @@ _CTX_SELECTED_CAP = 4000
 _CTX_FILE_RE = re.compile(r"\b[\w./-]+\.(?:py|js|ts|json|md|txt|ya?ml|sh|go|rs)\b")
 _CTX_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
 
+# The serve's own reject-status surface (emit.py composes it). In-session
+# rejects accumulate on the append-only wire; rendered back into generation
+# seats they are noise, not conversation (live finding 2026-07-09).
+_SERVE_STATUS_PREFIX = "Another round needed:"
+
 
 def _task_from(messages: Sequence[Any]) -> str:
     """The latest user message — clients send the full history every turn.
@@ -210,6 +215,8 @@ def _render_text(message: Any, role: str) -> str | None:
     content, keeping the transcript line-anchored for workspace extraction."""
     content = getattr(message, "content", None)
     if isinstance(content, str) and content.strip():
+        if role == "assistant" and content.strip().startswith(_SERVE_STATUS_PREFIX):
+            return None
         flat = " ".join(content.strip().split())
         return f"{role}: {flat[:_CTX_TEXT_CAP]}"
     return None

--- a/src/llm_orc/web/serving/turn_trace.py
+++ b/src/llm_orc/web/serving/turn_trace.py
@@ -16,6 +16,7 @@ is later adopted. No new dependency, no infra.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -23,10 +24,21 @@ from typing import Any
 _SNIPPET = 280
 
 
+def _snippet_cap() -> int:
+    """The response clip length: readable-short by default,
+    ``LLM_ORC_SERVE_TRACE_SNIPPET`` raises it for live diagnosis."""
+    raw = os.environ.get("LLM_ORC_SERVE_TRACE_SNIPPET", "")
+    try:
+        return int(raw) if raw else _SNIPPET
+    except ValueError:
+        return _SNIPPET
+
+
 def _snippet(value: Any) -> str:
+    cap = _snippet_cap()
     text = value if isinstance(value, str) else json.dumps(value)
     text = " ".join(text.split())
-    return text if len(text) <= _SNIPPET else text[:_SNIPPET] + "…"
+    return text if len(text) <= cap else text[:cap] + "…"
 
 
 def _child_results(response: Any) -> dict[str, Any] | None:

--- a/tests/unit/serving/test_serving_accept_gate.py
+++ b/tests/unit/serving/test_serving_accept_gate.py
@@ -123,6 +123,50 @@ def test_gate_rejects_when_executor_fails() -> None:
     assert g["accept"] is False
 
 
+def _gate_no_judge(
+    executor_resp: dict[str, Any], gather_resp: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Drive the gate as the held round wires it: executor + gather, no judge."""
+    deps: dict[str, Any] = {"executor": {"response": json.dumps(executor_resp)}}
+    if gather_resp is not None:
+        deps["gather"] = {"response": json.dumps(gather_resp)}
+    out = subprocess.run(
+        [sys.executable, str(GATE)],
+        input=json.dumps({"dependencies": deps}),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    result: dict[str, Any] = json.loads(out)
+    return result
+
+
+def test_gate_carries_round1_adequacy_on_a_held_round() -> None:
+    """The TDD retry round (issue #100): the held path only fires when round
+    1's judge passed the tests, so with no judge seat the gate carries that
+    verdict deterministically — the executor stays the live ground truth."""
+    g = _gate_no_judge({"tests_pass": True}, {"held": True})
+    assert g["tests_adequate"] is True
+    assert g["accept"] is True
+    assert "carried" in g["reason"]
+
+
+def test_gate_held_round_still_rejects_when_tests_fail() -> None:
+    g = _gate_no_judge({"tests_pass": False}, {"held": True})
+    assert g["accept"] is False
+    assert g["tests_adequate"] is True
+    # the carried verdict must not mask the live failure cause
+    assert "tests did not pass" in g["reason"]
+
+
+def test_gate_without_judge_and_not_held_rejects() -> None:
+    """No judge and no held flag is a miswired shape, not a free pass."""
+    g = _gate_no_judge({"tests_pass": True}, {"held": False})
+    assert g["accept"] is False
+    g2 = _gate_no_judge({"tests_pass": True})
+    assert g2["accept"] is False
+
+
 def test_quoted_string_false_from_the_judge_does_not_pass_the_gate() -> None:
     """Small models sometimes quote booleans; bool("false") is True in
     Python, which would wave inadequate tests through the gate."""

--- a/tests/unit/serving/test_serving_accept_gather.py
+++ b/tests/unit/serving/test_serving_accept_gather.py
@@ -133,6 +133,27 @@ def test_gather_assembles_requirement_code_tests_from_seats() -> None:
     assert out["tests"] == TESTS
 
 
+def test_gather_code_drops_a_seat_emitted_test_fence_from_the_deliverable() -> None:
+    """Seat models sometimes emit the code and a copy of the tests as two
+    fences; joining them pollutes the shipped file with embedded tests (live
+    finding 2026-07-09: models.py shipped with the test suite appended). The
+    CODE extraction drops pure-test blocks when a non-test block exists."""
+    chatty_code = (
+        "Here is the code:\n```python\n" + CODE + "\n```\n"
+        "And the tests:\n```python\n" + TESTS + "\n```\n"
+    )
+    out = _gather("Write is_even(n).", TESTS, chatty_code)
+    assert out["code"] == CODE
+    assert "def test_" not in out["code"]
+
+
+def test_gather_tests_keep_test_fences() -> None:
+    """The TESTS extraction must not drop test blocks (they are the point)."""
+    chatty_tests = "```python\n" + TESTS + "\n```"
+    out = _gather("Write is_even(n).", chatty_tests, CODE)
+    assert out["tests"] == TESTS
+
+
 def test_gather_strips_markdown_fences_from_seat_output() -> None:
     fenced_code = "Here you go:\n```python\n" + CODE + "\n```\n"
     fenced_tests = "```python\n" + TESTS + "\n```"

--- a/tests/unit/serving/test_serving_accept_gather.py
+++ b/tests/unit/serving/test_serving_accept_gather.py
@@ -74,6 +74,58 @@ def _executor_from_gather(gather_out: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _gather_code_only(criteria: str, code_terminal: str) -> dict[str, Any]:
+    """Drive gather as the held round wires it: no test_writer dependency."""
+    payload = json.dumps(
+        {
+            "input_data": criteria,
+            "dependencies": {
+                "code_writer": {"response": _sub_ensemble_response(code_terminal)},
+            },
+        }
+    )
+    out = subprocess.run(
+        [sys.executable, str(GATHER)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    result: dict[str, Any] = json.loads(out)
+    return result
+
+
+_HELD_MARKER = "[HELD TESTS: round 1 spec; regenerate ONLY the code]"
+
+
+def test_gather_reads_held_tests_when_test_writer_is_absent() -> None:
+    """The TDD retry round (issue #100): build-code-round has no test_writer;
+    gather reads the held tests from the carry's sentinel block and marks the
+    contract held so the gate carries round 1's adequacy verdict."""
+    criteria = (
+        "Write is_even(n) in even.py\n\n"
+        "[Previous round rejected: tests did not pass."
+        " Executor report: test_even: AssertionError().]\n\n"
+        f"{_HELD_MARKER}\n```python\n{TESTS}\n```"
+    )
+    out = _gather_code_only(criteria, CODE)
+    assert out["tests"] == TESTS
+    assert out["code"] == CODE
+    assert out["held"] is True
+    assert "[HELD TESTS" not in out["requirement"]
+    assert "Write is_even(n) in even.py" in out["requirement"]
+
+
+def test_gather_with_test_writer_ignores_a_marker_in_the_turn_text() -> None:
+    """A fresh round whose turn text happens to contain the sentinel string
+    still takes its tests from test_writer (worst case is a rejected round,
+    never a wrong accept)."""
+    criteria = f"Write is_even(n). By the way: {_HELD_MARKER}"
+    out = _gather(criteria, TESTS, CODE)
+    assert out["tests"] == TESTS
+    assert out.get("held", False) is False
+
+
 def test_gather_assembles_requirement_code_tests_from_seats() -> None:
     out = _gather("Write is_even(n).", TESTS, CODE)
     assert out["requirement"] == "Write is_even(n)."

--- a/tests/unit/serving/test_serving_build_gated_envelope.py
+++ b/tests/unit/serving/test_serving_build_gated_envelope.py
@@ -100,18 +100,20 @@ def _envelope_with_input(
     gate_verdict: dict[str, Any],
     base_input: str,
     executor_report: str = "",
+    executor_extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    executor_result: dict[str, Any] = {
+        "tests_pass": False,
+        "report": executor_report,
+    }
+    executor_result.update(executor_extra or {})
     payload = json.dumps(
         {
             "input_data": base_input,
             "dependencies": {
                 "code_writer": {"response": _sub_ensemble_response(code_terminal)},
                 "accept_gate": {"response": json.dumps(gate_verdict)},
-                "executor": {
-                    "response": json.dumps(
-                        {"tests_pass": False, "report": executor_report}
-                    )
-                },
+                "executor": {"response": json.dumps(executor_result)},
             },
         }
     )
@@ -140,6 +142,65 @@ def test_reject_envelope_composes_a_retry_input_for_the_next_round() -> None:
     retry = env["diagnostics"]["retry_input"]
     assert "Write f() in f.py" in retry
     assert "test_f: AssertionError()" in retry
+
+
+def test_reject_with_ran_adequate_tests_carries_them_held_in_retry_input() -> None:
+    """The TDD retry loop (issue #100): when the round's tests collected and
+    ran (n_tests > 0) and the judge passed them, the reject carry embeds the
+    tests under the HELD TESTS sentinel — round 2 holds them as the spec and
+    regenerates only the code."""
+    env = _envelope_with_input(
+        "def f():\n    return 2",
+        {
+            "accept": False,
+            "tests_pass": False,
+            "tests_adequate": True,
+            "reason": "tests did not pass",
+        },
+        base_input="Write f() in f.py",
+        executor_report="test_f: AssertionError()",
+        executor_extra={"n_tests": 2, "tests": "def test_f():\n    assert f() == 1"},
+    )
+    retry = env["diagnostics"]["retry_input"]
+    assert "Write f() in f.py" in retry
+    assert "[HELD TESTS" in retry
+    assert "def test_f():\n    assert f() == 1" in retry
+
+
+def test_reject_with_uncollected_tests_regenerates_fresh() -> None:
+    """Tests that never collected (n_tests == 0) are not a spec — the carry
+    stays the fresh-regeneration form."""
+    env = _envelope_with_input(
+        "def f():\n    return 2",
+        {
+            "accept": False,
+            "tests_pass": False,
+            "tests_adequate": True,
+            "reason": "tests did not pass",
+        },
+        base_input="Write f() in f.py",
+        executor_report="no test_* functions or TestCase classes found",
+        executor_extra={"n_tests": 0, "tests": "garbage"},
+    )
+    retry = env["diagnostics"]["retry_input"]
+    assert "[HELD TESTS" not in retry
+    assert "Write f() in f.py" in retry
+
+
+def test_reject_with_inadequate_tests_regenerates_fresh() -> None:
+    """Judge-rejected tests are not a spec worth holding."""
+    env = _envelope_with_input(
+        "def f():\n    return 2",
+        {
+            "accept": False,
+            "tests_pass": True,
+            "tests_adequate": False,
+            "reason": "tests inadequate to verify the requirement",
+        },
+        base_input="Write f() in f.py",
+        executor_extra={"n_tests": 2, "tests": "def test_f():\n    assert True"},
+    )
+    assert "[HELD TESTS" not in env["diagnostics"]["retry_input"]
 
 
 def test_accept_envelope_has_no_retry_input() -> None:

--- a/tests/unit/serving/test_serving_build_gated_envelope.py
+++ b/tests/unit/serving/test_serving_build_gated_envelope.py
@@ -203,6 +203,36 @@ def test_reject_with_inadequate_tests_regenerates_fresh() -> None:
     assert "[HELD TESTS" not in env["diagnostics"]["retry_input"]
 
 
+def test_envelope_marks_a_held_round_in_diagnostics() -> None:
+    """Observability for the TDD retry loop: the round's mode is only
+    knowable live from the envelope, so a held round (gather dep carries
+    held=true) stamps diagnostics.held_round."""
+    payload = json.dumps(
+        {
+            "input_data": "Write f() in f.py",
+            "dependencies": {
+                "code_writer": {"response": _sub_ensemble_response("x = 1")},
+                "accept_gate": {"response": json.dumps({"accept": True})},
+                "gather": {"response": json.dumps({"held": True})},
+            },
+        }
+    )
+    out = subprocess.run(
+        [sys.executable, str(ENVELOPE)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    env = json.loads(out)
+    assert env["diagnostics"]["held_round"] is True
+
+
+def test_envelope_marks_a_fresh_round_without_gather_held() -> None:
+    env = _envelope("x = 1", {"accept": True, "reason": "ok"})
+    assert env["diagnostics"]["held_round"] is False
+
+
 def test_accept_envelope_has_no_retry_input() -> None:
     env = _envelope_with_input(
         "def f():\n    return 1",

--- a/tests/unit/serving/test_serving_build_gated_envelope.py
+++ b/tests/unit/serving/test_serving_build_gated_envelope.py
@@ -87,6 +87,17 @@ def test_envelope_extracts_code_from_fenced_seat_output() -> None:
     assert env["artifacts"][0]["content"] == "x = 1"
 
 
+def test_envelope_drops_a_seat_emitted_test_fence_from_the_deliverable() -> None:
+    """The shipped artifact must be the code, not code + an embedded copy of
+    the tests (two-fence seat output; live finding 2026-07-09)."""
+    env = _envelope(
+        "Code:\n```python\nx = 1\n```\nTests:\n"
+        "```python\ndef test_x():\n    assert x == 1\n```",
+        {"accept": True, "reason": "ok"},
+    )
+    assert env["artifacts"][0]["content"] == "x = 1"
+
+
 def test_envelope_preserves_adr024_container_without_retired_subfields() -> None:
     env = _envelope("x = 1", {"accept": True, "reason": "ok"})
     for field in ("primary", "structured", "artifacts", "diagnostics"):

--- a/tests/unit/serving/test_serving_build_round.py
+++ b/tests/unit/serving/test_serving_build_round.py
@@ -11,13 +11,22 @@ round envelope so the loop's ``until``/``carry`` predicates keep reading
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from llm_orc.core.config.ensemble_config import EnsembleLoader
+from llm_orc.core.execution.executor_factory import ExecutorFactory
 
 REPO = Path(__file__).resolve().parents[3]
 SCRIPTS = REPO / ".llm-orc" / "scripts" / "agentic_serving"
+ENSEMBLES = REPO / ".llm-orc" / "ensembles" / "agentic-serving"
 ROUTE = SCRIPTS / "route_round.py"
 UNWRAP = SCRIPTS / "dispatch_unwrap.py"
 
@@ -109,3 +118,65 @@ def test_build_code_round_has_no_test_writer_and_gate_reads_gather() -> None:
     assert "judge" not in names
     gate = next(a for a in config.agents if a.name == "accept_gate")
     assert set(gate.depends_on) == {"executor", "gather"}
+
+
+# --- integration: the real held-round graph through the real engine ---
+# build-code-round has no model nodes, so with an echo code-generator the
+# whole held path (route -> dispatch -> gather -> executor -> gate ->
+# envelope -> unwrap) runs hermetically.
+
+_HELD_CARRY = (
+    "Write is_even(n) in even.py\n\n"
+    "[Previous round rejected: tests did not pass."
+    " Executor report: test_even: AssertionError().]\n\n"
+    f"{_HELD_MARKER}\n```python\n"
+    "def test_even():\n    assert is_even(4) is True\n"
+    "def test_odd():\n    assert is_even(3) is False\n```"
+)
+
+# single line, no backslashes: the script resolver treats a value containing
+# '\' as a file path (same constraint as the endpoint fixture's echo seat)
+_ECHO_CODE_GENERATOR = (
+    "name: code-generator\n"
+    "description: deterministic echo seat for the held-round integration test\n"
+    "agents:\n"
+    "  - name: out\n"
+    "    script: \"echo 'def is_even(n): return n % 2 == 0'\"\n"
+)
+
+
+@pytest.mark.asyncio
+async def test_held_carry_runs_the_code_only_round_end_to_end() -> None:
+    """A held carry drives the REAL build-round graph: route picks
+    build-code-round, dispatch executes it, gather holds the carried tests,
+    the executor passes the echoed code against them, the gate carries round
+    1's adequacy, and unwrap restores the bare accepted envelope the loop's
+    ``until`` predicate reads."""
+    with tempfile.TemporaryDirectory() as td:
+        proj = Path(td)
+        ens = proj / "ensembles"
+        ens.mkdir()
+        scripts = proj / "scripts" / "agentic_serving"
+        scripts.parent.mkdir()
+        shutil.copytree(SCRIPTS, scripts)
+        shutil.copy(ENSEMBLES / "build-round.yaml", ens / "build-round.yaml")
+        shutil.copy(ENSEMBLES / "build-code-round.yaml", ens / "build-code-round.yaml")
+        (ens / "code-generator.yaml").write_text(_ECHO_CODE_GENERATOR)
+
+        config = EnsembleLoader().load_from_file(str(ens / "build-round.yaml"))
+        executor = ExecutorFactory.create_root_executor(project_dir=proj)
+        mock_artifact = Mock()
+        mock_artifact.save_execution_results = Mock()
+        with patch.object(executor, "_artifact_manager", mock_artifact):
+            result = await executor.execute(config, _HELD_CARRY)
+
+    unwrap = result["results"]["unwrap"]
+    assert unwrap["status"] == "success", unwrap
+    envelope = json.loads(unwrap["response"])
+    diag = envelope["diagnostics"]
+    assert diag["tests_pass"] is True, diag
+    assert diag["tests_adequate"] is True
+    assert "carried" in diag["accept_reason"]
+    assert diag["accept"] is True
+    assert diag["held_round"] is True
+    assert "def is_even" in envelope["primary"]

--- a/tests/unit/serving/test_serving_build_round.py
+++ b/tests/unit/serving/test_serving_build_round.py
@@ -1,0 +1,111 @@
+"""Unit tests for the build-round router nodes (issue #100).
+
+The TDD retry loop's body is a deterministic router: ``route`` picks the
+round shape from the carried input (fresh TDD round, or the held round when
+the carry bears the HELD TESTS sentinel), ``dispatch`` runs it, and
+``dispatch_unwrap`` peels the dispatch wrapper back to the bare ADR-024
+round envelope so the loop's ``until``/``carry`` predicates keep reading
+``${diagnostics.*}`` unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPTS = REPO / ".llm-orc" / "scripts" / "agentic_serving"
+ROUTE = SCRIPTS / "route_round.py"
+UNWRAP = SCRIPTS / "dispatch_unwrap.py"
+
+_HELD_MARKER = "[HELD TESTS: round 1 spec; regenerate ONLY the code]"
+
+
+def _run(script: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    out = subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    result: dict[str, Any] = json.loads(out)
+    return result
+
+
+def test_route_sends_a_fresh_turn_to_the_full_tdd_round() -> None:
+    out = _run(ROUTE, {"input": "Write is_even(n) in even.py"})
+    assert out["target"] == "build-gated-round"
+    assert out["round_input"] == "Write is_even(n) in even.py"
+
+
+def test_route_sends_a_held_carry_to_the_code_only_round() -> None:
+    carry = (
+        "Write is_even(n) in even.py\n\n"
+        "[Previous round rejected: tests did not pass.]\n\n"
+        f"{_HELD_MARKER}\n```python\ndef test_even():\n    assert is_even(4)\n```"
+    )
+    out = _run(ROUTE, {"input": carry})
+    assert out["target"] == "build-code-round"
+    assert out["round_input"] == carry
+
+
+def test_dispatch_unwrap_restores_the_bare_round_envelope() -> None:
+    envelope = {
+        "status": "success",
+        "primary": "x = 1",
+        "diagnostics": {"accept": True},
+    }
+    child_result = {
+        "ensemble": "build-gated-round",
+        "deliverable": json.dumps(envelope),
+        "results": {},
+    }
+    payload = {"dependencies": {"dispatch": {"response": json.dumps(child_result)}}}
+    assert _run(UNWRAP, payload) == envelope
+
+
+def test_dispatch_unwrap_emits_empty_object_when_deliverable_is_missing() -> None:
+    payload = {"dependencies": {"dispatch": {"response": json.dumps({"x": 1})}}}
+    assert _run(UNWRAP, payload) == {}
+
+
+# --- wiring: the loop body routes, and both round shapes are resolvable ---
+
+
+def _load(name: str) -> Any:
+    from llm_orc.core.config.ensemble_config import _find_ensemble_in_dirs
+
+    ensembles = REPO / ".llm-orc" / "ensembles"
+    return _find_ensemble_in_dirs(name, [str(ensembles)])
+
+
+def test_both_round_shapes_are_dispatch_discoverable_top_level() -> None:
+    """route's dispatch resolves names non-recursively at the ensembles top
+    level, so both targets need top-level entries (the symlink convention)."""
+    for name in ("build-round", "build-code-round"):
+        config = _load(name)
+        assert config is not None, name
+        assert config.name == name
+
+
+def test_build_gated_loop_body_is_the_router() -> None:
+    config = _load("build-gated")
+    assert config is not None
+    round_agent = next(a for a in config.agents if a.name == "round")
+    assert round_agent.loop.body == "build-round"
+
+
+def test_build_code_round_has_no_test_writer_and_gate_reads_gather() -> None:
+    """The held round: code-only against the carried spec; the gate carries
+    round 1's adequacy from gather's held flag (no judge seat)."""
+    config = _load("build-code-round")
+    assert config is not None
+    names = {a.name for a in config.agents}
+    assert "test_writer" not in names
+    assert "judge" not in names
+    gate = next(a for a in config.agents if a.name == "accept_gate")
+    assert set(gate.depends_on) == {"executor", "gather"}

--- a/tests/unit/web/serving/test_serving_context_render.py
+++ b/tests/unit/web/serving/test_serving_context_render.py
@@ -283,6 +283,26 @@ def test_selected_write_is_not_duplicated_when_already_in_the_tail() -> None:
     assert rendered.count("[wrote models.py]") == 1
 
 
+def test_serve_reject_status_messages_are_excluded_from_the_render() -> None:
+    """'Another round needed: ...' is the serve's own reject-status surface
+    (emit.py), not conversation content — in-session rejects accumulate on
+    the append-only wire and feed generation seats as noise (live finding
+    2026-07-09: three consecutive storage.py rejects in-session while the
+    same task accepted via direct invoke without the noise)."""
+    messages = [
+        ChatMessage(role="user", content="Create storage.py with TaskStore"),
+        ChatMessage(
+            role="assistant", content="Another round needed: tests did not pass"
+        ),
+        ChatMessage(role="user", content="try again"),
+    ]
+
+    rendered = _render_context(messages)
+
+    assert "Another round needed" not in rendered
+    assert "user: Create storage.py with TaskStore" in rendered
+
+
 def test_write_truncated_out_of_the_tail_render_is_still_selected() -> None:
     """A write inside the 8-message tail window can still be sliced off the
     FRONT of the tail render by the tail char cap — it must then be selected

--- a/tests/unit/web/serving/test_turn_trace_snippet.py
+++ b/tests/unit/web/serving/test_turn_trace_snippet.py
@@ -1,0 +1,36 @@
+"""Unit tests for the turn-trace snippet cap.
+
+The trace clips node responses to a short snippet by default so the JSONL
+stays readable; ``LLM_ORC_SERVE_TRACE_SNIPPET`` raises the cap for live
+diagnosis sessions (two 2026-07-09 loop investigations dead-ended on the
+280-char clip hiding the round envelope's diagnostics).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_orc.web.serving.turn_trace import build_turn_trace
+
+
+def _trace_response(length: int) -> str:
+    result = {"results": {"node": {"status": "success", "response": "x" * length}}}
+    trace = build_turn_trace("serving", result)
+    response: str = trace["nodes"][0]["response"]
+    return response
+
+
+def test_snippet_clips_at_the_default_cap() -> None:
+    assert len(_trace_response(5000)) == 281  # 280 + ellipsis
+
+
+def test_snippet_cap_is_env_configurable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLM_ORC_SERVE_TRACE_SNIPPET", "5000")
+    assert len(_trace_response(4000)) == 4000
+
+
+def test_unparseable_snippet_env_falls_back_to_the_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_ORC_SERVE_TRACE_SNIPPET", "lots")
+    assert len(_trace_response(5000)) == 281


### PR DESCRIPTION
Closes #100.

**Core:** the accept-gate retry loop's body is now `build-round`, a deterministic router. A reject whose tests collected and were judged adequate carries them under a HELD TESTS sentinel; round 2 dispatches to the new `build-code-round` — code_writer only, gather reads the held tests from the carry, the gate carries round 1's adequacy verdict, the executor stays the live ground truth. Collection failures and judge-rejected tests still regenerate fresh. Pure composition on shipped primitives (loop / dispatch / scripts); zero engine changes.

**Proven:**
- Hermetic: the real `build-round` graph through the real engine (echo seat) — route → dispatch → gather(held) → executor → gate(carried) → envelope → unwrap, accepted.
- Live: a held carry through `llm-orc invoke build-round` with qwen3:8b — code regenerated against the held tests, accepted with `held_round: true`, reason "tests pass; adequacy carried from round 1".

**Live-diagnosis fixes that rode along** (each with the observed failure in its commit):
- The serve's own "Another round needed:" status turns are filtered from the context render (append-only wire accumulates them as generation-seat noise).
- Code extraction drops seat-emitted test fences — deliverables were shipping with the test suite embedded.
- test-writer prompt bans reflection-style tests (hasattr/callable): they fail right implementations and pass wrong ones; observed as the 8b seat's dominant dataclass-task mode.
- Observability: `diagnostics.held_round` marks each round's mode; `LLM_ORC_SERVE_TRACE_SNIPPET` deepens the turn trace for live diagnosis.

**Key finding for the path:** the held retry fires only when round 1's tests are adequate — judge adequacy (#84) and test-writer quality (#98) directly bound its live win-rate; the roadmap raises the gate integrity pair accordingly. Non-code turns (explain, turn-1 recall) verified green through real OpenCode after all changes.

2561 tests, mypy strict + ruff clean.