### PR TITLE
Gate integrity #98: the write-tests shape — the test deliverable runs against the workspace alone

### DIFF
--- a/.llm-orc/ensembles/agentic-serving/serving.yaml
+++ b/.llm-orc/ensembles/agentic-serving/serving.yaml
@@ -49,6 +49,9 @@ agents:
       Choose "code-seat" when the request is for a code ARTIFACT to be produced
       or changed, even when phrased as a noun rather than a command.
 
+      Choose "tests-seat" when the request's DELIVERABLE is tests for existing
+      code — tests are the object of the request, not a trailing mention.
+
       Choose "explainer" when the request is for UNDERSTANDING in prose: an
       explanation, comparison, description, or answer, with no code artifact
       being requested.
@@ -57,11 +60,12 @@ agents:
       "a function that checks whether a number is prime" -> {"target": "code-seat"}
       "a script to rename files in a folder" -> {"target": "code-seat"}
       "fix the off-by-one in the loop" -> {"target": "code-seat"}
+      "coverage for the storage module" -> {"target": "tests-seat"}
       "the difference between a list and a tuple" -> {"target": "explainer"}
       "how does async work in Python" -> {"target": "explainer"}
 
       Respond with ONLY a JSON object, no other text and no code fences:
-      {"target": "code-seat"} or {"target": "explainer"}
+      {"target": "code-seat"}, {"target": "tests-seat"} or {"target": "explainer"}
 
   - name: resolve
     script: scripts/agentic_serving/resolve.py

--- a/.llm-orc/ensembles/agentic-serving/test-writer.yaml
+++ b/.llm-orc/ensembles/agentic-serving/test-writer.yaml
@@ -46,5 +46,8 @@ agents:
         "expected <Error>"` after the call. NEVER call assertRaises or
         assertRaisesRegex bare — they are unittest METHODS and do not
         exist as functions (NameError at runtime).
+      - Assert the exception TYPE only; NEVER assert exception message
+        text (the task does not specify messages, and str(KeyError(x))
+        adds quotes).
       - Output ONLY the test code: a series of `def test_*():` functions, with
         no prose and no markdown code fences.

--- a/.llm-orc/ensembles/agentic-serving/test-writer.yaml
+++ b/.llm-orc/ensembles/agentic-serving/test-writer.yaml
@@ -42,5 +42,9 @@ agents:
         reflection-style checks — no hasattr, callable, or isinstance
         tests. They pass wrong implementations and fail right ones (a
         dataclass field with no default is not a class attribute).
+      - For an expected exception, use try/except with `assert False,
+        "expected <Error>"` after the call. NEVER call assertRaises or
+        assertRaisesRegex bare — they are unittest METHODS and do not
+        exist as functions (NameError at runtime).
       - Output ONLY the test code: a series of `def test_*():` functions, with
         no prose and no markdown code fences.

--- a/.llm-orc/ensembles/agentic-serving/write-tests-round.yaml
+++ b/.llm-orc/ensembles/agentic-serving/write-tests-round.yaml
@@ -1,0 +1,45 @@
+name: write-tests-round
+description: |
+  One write-tests round (#98): the deliverable IS the test file, executed
+  against the materialized workspace alone. One test source — no
+  code_writer, so the shadowed-composite wrong-accept (issue #98: the gate
+  validated a composite while the shipped test file carried a broken test)
+  is structurally impossible; the artifact that ships is the artifact that
+  ran.
+
+  Pipeline:
+    test_writer   tests for the workspace code, from the turn's criteria
+    gather        {requirement, code: "", tests, workspace}; deterministic
+                  workspace-import injection; no target_file (no shadow)
+    executor      deterministic, sandboxed: runs the tests against the
+                  materialized workspace
+    judge         deterministic: value-bearing-assert analysis (#84)
+    accept_gate   accept = tests_pass AND tests_adequate
+    envelope      the executor-echoed tests as the ADR-024 primary
+
+# The retry-loop body — not registry-facing (no topaz_skill, no serves);
+# resolved only by write-tests' loop node.
+
+agents:
+  - name: test_writer
+    ensemble: test-writer
+
+  - name: gather
+    script: scripts/agentic_serving/tests_gather.py
+    depends_on: [test_writer]
+
+  - name: executor
+    script: scripts/agentic_serving/accept_executor.py
+    depends_on: [gather]
+
+  - name: judge
+    script: scripts/agentic_serving/adequacy_check.py
+    depends_on: [executor]
+
+  - name: accept_gate
+    script: scripts/agentic_serving/accept_gate.py
+    depends_on: [executor, judge]
+
+  - name: envelope
+    script: scripts/agentic_serving/tests_envelope.py
+    depends_on: [executor, accept_gate]

--- a/.llm-orc/ensembles/agentic-serving/write-tests.yaml
+++ b/.llm-orc/ensembles/agentic-serving/write-tests.yaml
@@ -1,0 +1,40 @@
+name: write-tests
+description: |
+  The test-writing shape (#98): classify routes a test-primary turn
+  (tests as the OBJECT of the request, or a named test_*.py file) here via
+  the tests-seat intent. The engine's loop primitive re-runs
+  write-tests-round until the accept verdict holds or the bound trips; a
+  reject carries a fresh-regeneration retry_input (no held mode — tests
+  are the moving side by definition, and the executor's real-workspace
+  failure report is the retry evidence). unwrap peels the loop wrapper
+  back to the bare ADR-024 envelope for the serving marshal. Deterministic
+  control: closed bound, predicates over deterministic verdicts.
+
+topaz_skill: code_generation
+serves: tests-seat
+
+agents:
+  - name: round
+    timeout_seconds: 660
+    loop:
+      body: write-tests-round
+      until: "${diagnostics.accept}"
+      max_iterations: 2
+      carry: "${diagnostics.retry_input}"
+
+  - name: unwrap
+    script: scripts/agentic_serving/loop_unwrap.py
+    depends_on: [round]
+
+# Seat-owned admission contract (ADR-046 §2): black-box, same granularity
+# as the default build seat's — an accept-rejected turn still emits a
+# well-formed envelope (the tests are present), so the seat contract admits
+# it and the loop-level accept verdict rides in diagnostics.
+seat_contract:
+  behavioral:
+    - name: envelope-status-success
+      description: "the seat produced a success envelope"
+      assertion: "results['seat']['status'] == 'success'"
+    - name: envelope-carries-artifact
+      description: "the seat envelope carries a deliverable artifact"
+      assertion: "len(results['seat']['artifacts']) > 0"

--- a/.llm-orc/ensembles/write-tests-round.yaml
+++ b/.llm-orc/ensembles/write-tests-round.yaml
@@ -1,0 +1,1 @@
+agentic-serving/write-tests-round.yaml

--- a/.llm-orc/ensembles/write-tests.yaml
+++ b/.llm-orc/ensembles/write-tests.yaml
@@ -1,0 +1,1 @@
+agentic-serving/write-tests.yaml

--- a/.llm-orc/scripts/agentic_serving/accept_executor_runner.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor_runner.py
@@ -18,7 +18,24 @@ from __future__ import annotations
 
 import json
 import sys
+import traceback
 from pathlib import Path
+
+
+def _failing_line(error: Exception, tests: str) -> str:
+    """The failing source line from the tests, when the last traceback frame
+    lands there — a bare 'AssertionError()' gives the retry round nothing to
+    move on; the offending expectation is the actionable evidence."""
+    tb = error.__traceback__
+    if tb is None:
+        return ""
+    frames = traceback.extract_tb(tb)
+    for frame in reversed(frames):
+        if frame.filename == "test_solution.py" and frame.lineno:
+            lines = tests.splitlines()
+            if 0 < frame.lineno <= len(lines):
+                return lines[frame.lineno - 1].strip()
+    return ""
 
 
 def run_tests(code: str, tests: str) -> tuple[bool, str, int]:
@@ -65,7 +82,11 @@ def run_tests(code: str, tests: str) -> tuple[bool, str, int]:
                 # uncollected it would count as a silent pass (wrong accept)
                 asyncio.run(result)
         except Exception as error:  # noqa: BLE001
-            failures.append(f"{name}: {error!r}")
+            line = _failing_line(error, tests)
+            detail = f"{name}: {error!r}"
+            if line:
+                detail += f" at: {line}"
+            failures.append(detail)
 
     if case_classes:
         loader = unittest.defaultTestLoader

--- a/.llm-orc/scripts/agentic_serving/classify.py
+++ b/.llm-orc/scripts/agentic_serving/classify.py
@@ -47,6 +47,16 @@ _EXPLAIN_MARKERS = (
 _INTERROGATIVE_RE = re.compile(r"^(what|why|how|when|where|which|who)\b", re.IGNORECASE)
 _DEFAULT_CODE_SEAT = "code-seat"
 _EXPLAIN_SEAT = "explainer"
+_TESTS_SEAT = "tests-seat"
+# Tests as the OBJECT of the request (issue #98): a build verb directly
+# asking for tests, or "tests for/of/against <target>". A trailing "with
+# tests" mention stays a code turn — routing it here would ship only tests.
+_TESTS_PRIMARY_RE = re.compile(
+    r"\b(?:write|add|create|generate|implement|build)\s+"
+    r"(?:some\s+|unit\s+|more\s+|the\s+)?tests?\b"
+    r"|\btests?\s+(?:for|of|against)\b",
+    re.IGNORECASE,
+)
 _FILE_RE = re.compile(
     r"\b([\w./-]+\.(?:py|js|ts|jsx|tsx|json|md|txt|ya?ml|sh|go|rs|java|c|cpp|h))\b"
 )
@@ -102,8 +112,17 @@ def main() -> None:
     named_file = turn.get("file") or _extract_file(task)
     has_build_signal = bool(named_file) or bool(_BUILD_RE.search(task))
 
+    named_basename = named_file.rsplit("/", 1)[-1] if named_file else ""
+    tests_primary = bool(_TESTS_PRIMARY_RE.search(task)) or named_basename.startswith(
+        "test_"
+    )
+
     if is_explain:
         target, kind, build, needs_decider = _EXPLAIN_SEAT, "explanation", False, False
+    elif tests_primary:
+        # the deliverable IS a test file, run against the workspace alone
+        # (issue #98) — never build-gated's code/tests duality
+        target, kind, build, needs_decider = _TESTS_SEAT, "python_tests", True, False
     elif has_build_signal:
         target = _DEFAULT_CODE_SEAT
         kind = turn.get("kind", "python_module")
@@ -112,7 +131,15 @@ def main() -> None:
         # No structural signal — hand the routing to the guarded model decider.
         target, kind, build, needs_decider = "", "", False, True
 
-    file = named_file or "solution.py"
+    if target == _TESTS_SEAT:
+        if named_basename.startswith("test_"):
+            file = named_file
+        elif named_basename:
+            file = f"test_{named_basename}"
+        else:
+            file = "test_solution.py"
+    else:
+        file = named_file or "solution.py"
 
     # Rung-1 conversation memory: context composes into dispatch_input behind
     # the deterministic marker (generation seats resolve referents; verifier

--- a/.llm-orc/scripts/agentic_serving/resolve.py
+++ b/.llm-orc/scripts/agentic_serving/resolve.py
@@ -25,6 +25,7 @@ from llm_orc.core.serving.shape_catalog import shape_catalog
 _DERIVED = {
     "code-seat": ("python_module", True),
     "explainer": ("explanation", False),
+    "tests-seat": ("python_tests", True),
 }
 # The intent -> serving shape mapping is now operator-curated (WP-C8): each shape
 # declares the intent it ``serves`` and the Shape Catalog derives the map from the

--- a/.llm-orc/scripts/agentic_serving/tests_envelope.py
+++ b/.llm-orc/scripts/agentic_serving/tests_envelope.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""write-tests terminal — the ADR-024 envelope for a test deliverable (#98).
+
+Ships the EXECUTOR-ECHOED tests (the exact artifact that ran against the
+workspace) as the primary artifact, with the accept verdict in diagnostics.
+On reject, composes a fresh-regeneration retry carry — the write-tests
+shape has no held mode: tests are the moving side by definition, and the
+executor's real-workspace failure report is the retry evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from _helpers import deps as _deps
+from _helpers import payload as _payload
+from _helpers import response as _response
+
+
+def _parsed(deps: dict[str, object], name: str) -> dict[str, object]:
+    try:
+        parsed = json.loads(_response(deps.get(name, {})))
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def main() -> None:
+    payload = _payload(sys.stdin.read().strip())
+    deps = _deps(payload)
+    executor = _parsed(deps, "executor")
+    verdict = _parsed(deps, "accept_gate")
+    tests = str(executor.get("tests", ""))
+    summary = tests.splitlines()[0][:80] if tests.strip() else "test deliverable"
+
+    diagnostics = {
+        "ensemble": "write-tests",
+        "accept": bool(verdict.get("accept", False)),
+        "accept_reason": str(verdict.get("reason", "")),
+        "tests_pass": bool(verdict.get("tests_pass", False)),
+        "tests_adequate": bool(verdict.get("tests_adequate", False)),
+    }
+    if not diagnostics["accept"]:
+        report = str(executor.get("report", ""))
+        diagnostics["retry_input"] = (
+            f"{payload.get('input_data', '')}\n\n"
+            f"[Previous round rejected: {diagnostics['accept_reason']}."
+            f" Executor report against the workspace: {report}."
+            f" Regenerate the tests to exercise the workspace code's real"
+            f" behavior.]"
+        )
+
+    envelope = {
+        "status": "success",
+        "primary": tests,
+        "structured": {"content": tests},
+        "artifacts": [
+            {
+                "content_type": "text/x-python",
+                "content": tests,
+                "summary": summary,
+            }
+        ],
+        "diagnostics": diagnostics,
+    }
+    print(json.dumps(envelope))
+
+
+if __name__ == "__main__":
+    main()

--- a/.llm-orc/scripts/agentic_serving/tests_gather.py
+++ b/.llm-orc/scripts/agentic_serving/tests_gather.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""write-tests gather node — assemble the test-deliverable contract (#98).
+
+The write-tests shape's deliverable IS the test file: one test source
+(test_writer), empty code, the conversation workspace materialized for the
+executor to run the tests against. No target_file — nothing shadows, so the
+artifact that ships is exactly the artifact that executed (the issue #98
+wrong-accept was the gate validating a shadowed composite).
+
+Reuses accept_gather's extraction, context-splitting, and deterministic
+workspace-import injection via sibling import (one implementation).
+
+Emits JSON: {requirement, code, tests, workspace, target_file, held}
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from _helpers import payload as _payload
+from _helpers import response as _response
+from _helpers import terminal as _terminal
+from accept_gather import _REQUEST_MARKER, _extract_tests, _inject_workspace_imports
+from accept_gather import _workspace as _extract_workspace
+
+
+def main() -> None:
+    payload = _payload(sys.stdin.read().strip())
+    requirement = str(payload.get("input_data", ""))
+    workspace: dict[str, str] = {}
+    if _REQUEST_MARKER in requirement:
+        context, requirement = requirement.rsplit(_REQUEST_MARKER, 1)
+        workspace = _extract_workspace(context)
+    deps = payload.get("dependencies", {})
+    if not isinstance(deps, dict):
+        deps = {}
+
+    tests = _extract_tests(_terminal(_response(deps.get("test_writer", {}))))
+    tests = _inject_workspace_imports(tests, workspace)
+
+    print(
+        json.dumps(
+            {
+                "requirement": requirement,
+                "code": "",
+                "tests": tests,
+                "workspace": workspace,
+                "target_file": "",
+                "held": False,
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/plans/2026-07-09-write-tests-shape-design.md
+++ b/docs/plans/2026-07-09-write-tests-shape-design.md
@@ -1,0 +1,67 @@
+# The write-tests shape (#98, second half of the gate integrity pair)
+
+**Problem (long-horizon drive 2026-07-09, todoapp turn 4):** a "write
+tests" turn routes to build-gated, where test_writer AND code_writer both
+emit test files into ONE exec namespace; same-named functions from
+test_writer shadow the deliverable's, so the gate validated a shadowed
+composite and ACCEPTED while the shipped test_storage.py carried a broken
+test (10/11 pass in the workspace) — a wrong accept.
+
+**Fix (issue direction (b), approved sequence):** a dedicated shape where
+the deliverable IS the test file, executed against the materialized
+workspace alone.
+
+## Routing
+
+- classify: a test-primary turn — build verb + tests as the object
+  (`write/add/create/generate tests (for|of) ...`, or task-initial
+  "write tests...") or a named `test_*.py` file — routes to the new
+  intent `tests-seat`, `kind: python_tests`, `build: true`.
+  "write is_even WITH tests" stays code-seat (tests must be the object).
+- Deliverable filename, derived in classify: named `test_*.py` wins;
+  else `test_<named-module>.py`; else `test_solution.py`.
+- decide (guarded model): `tests-seat` joins the closed set;
+  resolve `_DERIVED` gains `tests-seat: ("python_tests", True)`.
+- Shape catalog: `write-tests` declares `serves: tests-seat`.
+
+## The shape
+
+`write-tests` (loop, until `${diagnostics.accept}`, max 2, carry
+`${diagnostics.retry_input}` — fresh regeneration only; tests are the
+moving side, the executor's real-workspace failure report is the retry
+evidence) over `write-tests-round`:
+
+    test_writer     existing test-writer ensemble, reused
+    tests_gather    tests = seat output; code = ""; workspace from the
+                    context; NO target_file (nothing shadows); reuses
+                    accept_gather's extraction + workspace-import
+                    injection via sibling import
+    executor        accept_executor.py unchanged (empty code, workspace
+                    materialized, deliverable tests run against it)
+    judge           adequacy_check.py reused
+    accept_gate     reused
+    tests_envelope  primary = the executor-echoed tests (the exact
+                    validated artifact); same diagnostics contract;
+                    fresh-only retry_input
+
+Both new ensembles are non-registry-facing except `write-tests`'s
+`serves:` declaration. Top-level symlinks per the dispatch-discovery
+convention. seat_contract admits via the standard success+artifact
+assertions.
+
+## What this closes
+
+The shipped artifact IS the executed artifact: one test source, run
+against the workspace alone — the shadowed-composite wrong-accept is
+structurally impossible.
+
+## Validation
+
+- Unit: classify routing boundaries (incl. the "with tests" negative and
+  test-filename derivation), tests_gather, tests_envelope.
+- Wiring: catalog maps tests-seat -> write-tests; round has no
+  code_writer; gate deps {executor, judge}.
+- Hermetic end-to-end: echo test-writer + a real workspace module through
+  the real engine; accepted envelope carries the tests as primary.
+- Live: build storage.py through OpenCode, then "write tests for
+  storage.py" — shipped file runs green against the workspace.

--- a/docs/serving-roadmap.md
+++ b/docs/serving-roadmap.md
@@ -144,10 +144,20 @@ after the swap: test-writer quality (reflection-style relapses now get
 correctly rejected instead of stochastically judged) — which is #98's
 territory.
 
-**#98 (next):** test-writing turns validate a shadowed composite in the
-shared exec namespace — route "write tests" to a dedicated shape (the
-deliverable IS the test file, run against the materialized workspace
-alone), reusing the deterministic adequacy checker.
+**#98 (shipped, write-tests-shape branch):** test-primary turns route via
+the new tests-seat intent to the write-tests shape — one test source, the
+deliverable executed against the materialized workspace alone, the
+deterministic checker and gate reused, the executor-echoed tests shipped
+as the artifact. The shadowed-composite wrong accept is structurally
+impossible. Live status (real OpenCode, storage.py session): routing,
+workspace execution, and honest rejection all verified — the shape
+refused exactly the broken-test class the old path shipped (store.list
+AttributeError, message-text assertions). Per-turn convergence is bounded
+by test-writer seat quality: the dominant residual is spec-free
+exception-MESSAGE assertions the 8b seat keeps regenerating despite
+prompt bans and line-level failure reports (both shipped here). Next
+lever is structural — escalation-on-signal seat tiering or a
+deterministic test sanitizer (path item 4), not more prompt rules.
 
 ### 4. Shapes and seat tiering
 

--- a/tests/unit/serving/test_serving_accept_gather.py
+++ b/tests/unit/serving/test_serving_accept_gather.py
@@ -378,6 +378,22 @@ def test_passing_async_tests_pass() -> None:
     assert result["tests_pass"] is True
 
 
+def test_failure_report_names_the_failing_source_line() -> None:
+    """A bare 'AssertionError()' gives the retry round nothing to move on
+    (live finding 2026-07-09: the same wrong expectation regenerated across
+    rounds). The report carries the failing line so the next round sees
+    WHICH expectation disagreed with the workspace."""
+    gathered = {
+        "requirement": "is_even",
+        "code": "def is_even(n):\n    return n % 2 == 0",
+        "tests": ("def test_wrong_expectation():\n    assert is_even(3) is True\n"),
+        "workspace": {},
+    }
+    result = _executor_from_gather(gathered)
+    assert result["tests_pass"] is False
+    assert "assert is_even(3) is True" in result["report"]
+
+
 def test_executor_reports_unittest_class_failures() -> None:
     gathered = {
         "requirement": "is_even",

--- a/tests/unit/serving/test_serving_classify.py
+++ b/tests/unit/serving/test_serving_classify.py
@@ -129,3 +129,43 @@ def test_routing_reads_the_task_never_the_context() -> None:
 def test_no_context_leaves_dispatch_input_as_the_bare_task() -> None:
     decision = _classify({"task": "write a function that adds two numbers"})
     assert decision["dispatch_input"] == "write a function that adds two numbers"
+
+
+# --- test-primary turns route to the tests-seat (#98) ---
+
+
+def test_write_tests_for_a_named_file_routes_to_the_tests_seat() -> None:
+    """A test-primary turn (tests as the OBJECT): the deliverable is a test
+    file run against the workspace, never build-gated's code/tests duality
+    (the shadowed-composite wrong-accept, issue #98)."""
+    decision = _classify({"task": "Write tests for storage.py"})
+    assert decision["target"] == "tests-seat"
+    assert decision["build"] is True
+    assert decision["kind"] == "python_tests"
+    assert decision["file"] == "test_storage.py"
+
+
+def test_add_tests_for_it_routes_to_the_tests_seat() -> None:
+    decision = _classify({"task": "add tests for it"})
+    assert decision["target"] == "tests-seat"
+    assert decision["file"] == "test_solution.py"
+
+
+def test_a_named_test_file_routes_to_the_tests_seat() -> None:
+    decision = _classify({"task": "update test_models.py with a case for done"})
+    assert decision["target"] == "tests-seat"
+    assert decision["file"] == "test_models.py"
+
+
+def test_with_tests_is_not_test_primary() -> None:
+    """'write is_even with tests' wants code (tests as a trailing mention);
+    routing it to the tests-seat would ship only tests."""
+    decision = _classify({"task": "write is_even with tests in even.py"})
+    assert decision["target"] == "code-seat"
+    assert decision["file"] == "even.py"
+
+
+def test_explain_still_outranks_the_tests_signal() -> None:
+    decision = _classify({"task": "what do the tests in test_foo.py cover?"})
+    assert decision["build"] is False
+    assert decision["target"] == "explainer"

--- a/tests/unit/serving/test_serving_resolve.py
+++ b/tests/unit/serving/test_serving_resolve.py
@@ -128,3 +128,13 @@ def test_intent_to_shape_routing_is_catalog_driven() -> None:
     catalog = shape_catalog(catalog_dir)
     assert catalog.get("code-seat") == "build-gated"  # the shipped default lane
     assert _resolve(_structural(target="code-seat"))["target"] == catalog["code-seat"]
+
+
+def test_decider_tests_seat_derives_python_tests_build() -> None:
+    """tests-seat joins the decider's closed set (#98)."""
+    out = _resolve(
+        {"needs_decider": True, "file": "test_x.py", "dispatch_input": "t"},
+        '{"target": "tests-seat"}',
+    )
+    assert out["kind"] == "python_tests"
+    assert out["build"] is True

--- a/tests/unit/serving/test_write_tests_shape.py
+++ b/tests/unit/serving/test_write_tests_shape.py
@@ -1,0 +1,237 @@
+"""Unit + wiring tests for the write-tests shape (#98).
+
+A test-primary turn's deliverable IS the test file, executed against the
+materialized workspace alone: one test source, no code_writer, so the
+shadowed-composite wrong-accept (gate validated a composite while the
+shipped test file carried a broken test) is structurally impossible. The
+shipped artifact is the executed artifact.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from llm_orc.core.config.ensemble_config import EnsembleLoader, _find_ensemble_in_dirs
+from llm_orc.core.execution.executor_factory import ExecutorFactory
+from llm_orc.core.serving.shape_catalog import shape_catalog
+from llm_orc.schemas.agent_config import LoopAgentConfig, ScriptAgentConfig
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPTS = REPO / ".llm-orc" / "scripts" / "agentic_serving"
+ENSEMBLES = REPO / ".llm-orc" / "ensembles"
+GATHER = SCRIPTS / "tests_gather.py"
+ENVELOPE = SCRIPTS / "tests_envelope.py"
+
+STORE_MODULE = (
+    "class TaskStore:\n"
+    "    def __init__(self):\n"
+    "        self.tasks = {}\n"
+    "    def add(self, task_id, title):\n"
+    "        self.tasks[task_id] = title\n"
+    "    def list_tasks(self):\n"
+    "        return list(self.tasks.values())\n"
+)
+TESTS = (
+    "def test_add_and_list():\n"
+    "    store = TaskStore()\n"
+    "    store.add(1, 'a')\n"
+    "    assert store.list_tasks() == ['a']\n"
+)
+CONTEXT_TASK = (
+    "Conversation so far:\n"
+    "assistant: [wrote storage.py]\n"
+    f"{STORE_MODULE}"
+    "\nCurrent request: Write tests for storage.py"
+)
+
+
+def _run(script: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    out = subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    result: dict[str, Any] = json.loads(out)
+    return result
+
+
+def _sub_ensemble_response(terminal_text: str) -> str:
+    return json.dumps(
+        {
+            "ensemble": "test-writer",
+            "status": "completed",
+            "results": {"out": {"response": terminal_text, "status": "success"}},
+        }
+    )
+
+
+# --- tests_gather: deliverable tests + workspace, no code, nothing shadows ---
+
+
+def test_gather_assembles_tests_as_the_deliverable_with_empty_code() -> None:
+    out = _run(
+        GATHER,
+        {
+            "input_data": CONTEXT_TASK,
+            "dependencies": {
+                "test_writer": {"response": _sub_ensemble_response(TESTS)},
+            },
+        },
+    )
+    assert out["code"] == ""
+    assert out["target_file"] == ""
+    assert "def test_add_and_list" in out["tests"]
+    assert out["workspace"] == {"storage.py": STORE_MODULE.strip()}
+    assert out["requirement"] == "Write tests for storage.py"
+
+
+def test_gather_injects_missing_workspace_imports_into_the_tests() -> None:
+    """The test-writer seat is prompted not to import; the workspace import
+    is injected deterministically (the shipped accept_gather behavior,
+    reused via sibling import)."""
+    out = _run(
+        GATHER,
+        {
+            "input_data": CONTEXT_TASK,
+            "dependencies": {
+                "test_writer": {"response": _sub_ensemble_response(TESTS)},
+            },
+        },
+    )
+    assert "from storage import TaskStore" in out["tests"]
+
+
+# --- tests_envelope: primary = the executor-echoed (validated) tests ---
+
+
+def _envelope(
+    verdict: dict[str, Any], executor_extra: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    executor: dict[str, Any] = {
+        "tests_pass": True,
+        "tests": TESTS,
+        "n_tests": 1,
+        "report": "all passed",
+    }
+    executor.update(executor_extra or {})
+    return _run(
+        ENVELOPE,
+        {
+            "input_data": "Write tests for storage.py",
+            "dependencies": {
+                "executor": {"response": json.dumps(executor)},
+                "accept_gate": {"response": json.dumps(verdict)},
+            },
+        },
+    )
+
+
+def test_envelope_ships_the_executed_tests_as_primary() -> None:
+    env = _envelope(
+        {"accept": True, "tests_pass": True, "tests_adequate": True, "reason": "ok"}
+    )
+    assert env["status"] == "success"
+    assert env["primary"] == TESTS
+    assert env["artifacts"][0]["content"] == TESTS
+    assert env["diagnostics"]["accept"] is True
+    assert "retry_input" not in env["diagnostics"]
+
+
+def test_envelope_reject_composes_a_fresh_retry_input() -> None:
+    env = _envelope(
+        {"accept": False, "tests_pass": False, "reason": "tests did not pass"},
+        executor_extra={
+            "tests_pass": False,
+            "report": "test_add_and_list: AttributeError('list')",
+        },
+    )
+    diag = env["diagnostics"]
+    assert diag["accept"] is False
+    retry = diag["retry_input"]
+    assert "Write tests for storage.py" in retry
+    assert "AttributeError" in retry
+    assert "[HELD TESTS" not in retry  # no held mode: tests are the moving side
+
+
+# --- wiring: catalog, loop, round shape ---
+
+
+def test_catalog_maps_the_tests_seat_intent_to_the_write_tests_shape() -> None:
+    catalog = shape_catalog(ENSEMBLES / "agentic-serving")
+    assert catalog["tests-seat"] == "write-tests"
+
+
+def test_write_tests_wraps_the_round_in_the_bounded_retry_loop() -> None:
+    config = _find_ensemble_in_dirs("write-tests", [str(ENSEMBLES)])
+    assert config is not None
+    round_agent = next(a for a in config.agents if a.name == "round")
+    assert isinstance(round_agent, LoopAgentConfig)
+    assert round_agent.loop.body == "write-tests-round"
+    assert round_agent.loop.max_iterations == 2
+
+
+def test_the_round_has_one_test_source_and_the_deterministic_verifiers() -> None:
+    config = _find_ensemble_in_dirs("write-tests-round", [str(ENSEMBLES)])
+    assert config is not None
+    names = {a.name for a in config.agents}
+    assert "code_writer" not in names
+    assert {"test_writer", "gather", "executor", "judge", "accept_gate"} <= names
+    judge = next(a for a in config.agents if a.name == "judge")
+    assert isinstance(judge, ScriptAgentConfig)
+    assert judge.script == "scripts/agentic_serving/adequacy_check.py"
+
+
+# --- hermetic end-to-end: the real round graph through the real engine ---
+
+# single line, no backslashes or nested quotes: the script resolver treats
+# '\' as a file path, and chr(97) dodges quoting inside the echo argument
+_ECHO_TEST_WRITER = (
+    "name: test-writer\n"
+    "description: deterministic echo seat for the write-tests e2e\n"
+    "agents:\n"
+    "  - name: out\n"
+    "    script: \"echo 'def test_add_and_list(): store = TaskStore();"
+    " store.add(1, chr(97)); assert store.list_tasks() == [chr(97)]'\"\n"
+)
+
+
+@pytest.mark.asyncio
+async def test_write_tests_round_accepts_against_the_workspace_end_to_end() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        proj = Path(td)
+        ens = proj / "ensembles"
+        ens.mkdir()
+        scripts = proj / "scripts" / "agentic_serving"
+        scripts.parent.mkdir()
+        shutil.copytree(SCRIPTS, scripts)
+        shutil.copy(
+            ENSEMBLES / "agentic-serving" / "write-tests-round.yaml",
+            ens / "write-tests-round.yaml",
+        )
+        (ens / "test-writer.yaml").write_text(_ECHO_TEST_WRITER)
+
+        config = EnsembleLoader().load_from_file(str(ens / "write-tests-round.yaml"))
+        executor = ExecutorFactory.create_root_executor(project_dir=proj)
+        mock_artifact = Mock()
+        mock_artifact.save_execution_results = Mock()
+        with patch.object(executor, "_artifact_manager", mock_artifact):
+            result = await executor.execute(config, CONTEXT_TASK)
+
+    envelope = json.loads(result["results"]["envelope"]["response"])
+    diag = envelope["diagnostics"]
+    assert diag["tests_pass"] is True, diag
+    assert diag["tests_adequate"] is True
+    assert diag["accept"] is True
+    assert "def test_add_and_list" in envelope["primary"]
+    assert "class TaskStore" not in envelope["primary"]  # tests only, no composite


### PR DESCRIPTION
Second half of the gate integrity pair. Closes #98.

**The defect:** a 'write tests' turn routed to build-gated, where test_writer AND code_writer both emit test files into ONE exec namespace — same-named functions shadow the deliverable's, so the gate validated a composite and ACCEPTED while the shipped test_storage.py carried a broken test (store.list AttributeError, 10/11 in the workspace).

**The shape:** classify routes test-primary turns (tests as the object — 'write/add/generate tests for …' — or a named test_*.py; 'write X *with* tests' stays code-seat) via the new `tests-seat` intent to `write-tests`: one test source, no code_writer, the deliverable executed against the materialized workspace, the deterministic adequacy checker (#84) and gate reused, and the envelope ships the executor-echoed tests. **The artifact that ships IS the artifact that ran** — the shadowed-composite wrong accept is structurally impossible. Bounded fresh-regeneration retry (no held mode: tests are the moving side; the real-workspace failure report is the retry evidence). Deliverable filename derives deterministically (test_<module>.py).

**Also shipped, from live validation:**
- Executor failure reports carry the failing source line — 'AssertionError()' gave the retry round nothing to move on; now it names WHICH expectation disagreed with the workspace (benefits build-gated retries too).
- test-writer prompt: bans bare assertRaises/assertRaisesRegex (unittest methods that NameError outside a class — observed 3×) and exception-MESSAGE assertions (spec-free; the str(KeyError) quoting gotcha).

**Verification:** 21 new tests — classify routing boundaries (incl. the with-tests negative), gather/envelope units, catalog + loop wiring, and a hermetic end-to-end of the real round graph through the real engine (echo seat + real workspace module → accept, tests-only primary). 2616 total, mypy strict + ruff clean.

**Live status (real OpenCode, storage.py session), stated honestly:** routing → write-tests verified; workspace execution verified; and the shape REFUSED to ship exactly the broken-test class the old path shipped — every reject grounded in a real workspace disagreement (bare assertRaisesRegex NameError, store.list AttributeError, message-text assertion). No green accept sample yet on this task: per-turn convergence is bounded by test-writer seat quality (the message-assertion pattern regenerates despite prompt bans and line-level reports). Next lever is structural — escalation-on-signal tiering or a deterministic test sanitizer (roadmap item 4), not more prompt rules. Roadmap updated accordingly.