### PR TITLE
Seat quality: deterministic gate repairs — isolation, sanitizer, import injection (path item 4)

### DIFF
--- a/.llm-orc/scripts/agentic_serving/accept_executor.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor.py
@@ -17,6 +17,7 @@ the contract and artifact to the isolated judge seat.
 from __future__ import annotations
 
 import ast
+import builtins
 import json
 import keyword
 import os
@@ -66,6 +67,72 @@ def _sanitize_tests(tests: str) -> tuple[str, int]:
             continue
         kept.append(line)
     return "\n".join(kept) + ("\n" if tests.endswith("\n") else ""), dropped
+
+
+# The 8b test-writer omits its own imports (live probe 2026-07-09:
+# os.path.exists / pytest.raises with no import lines) — a defect no code
+# regeneration can fix, since the code cannot define pytest. Deterministic
+# repair, same shape as gather's workspace-import injection: unbound
+# whitelisted module names get their import prepended, and the echoed
+# (shipped) tests carry it, making the artifact self-contained. Names
+# outside the whitelist stay uninjected and reject honestly.
+_INJECTABLE_MODULES = frozenset(
+    {
+        "collections", "functools", "itertools", "json", "math", "os",
+        "pathlib", "pytest", "re", "string", "sys", "tempfile", "time",
+        "unittest",
+    }
+)
+
+_BUILTIN_NAMES = frozenset(dir(builtins))
+
+
+def _param_names(args: ast.arguments) -> set[str]:
+    """Every name a function's parameter list binds, including *args/**kwargs."""
+    names = {a.arg for a in (*args.posonlyargs, *args.args, *args.kwonlyargs)}
+    if args.vararg:
+        names.add(args.vararg.arg)
+    if args.kwarg:
+        names.add(args.kwarg.arg)
+    return names
+
+
+def _bound_names(tree: ast.Module) -> set[str]:
+    """Every name the tests source binds: assignments, for/with targets (all
+    ``ast.Name`` in Store context), def/class names, function parameters, and
+    import aliases — the rest are candidates for import injection."""
+    bound = {
+        n.id
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Store)
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bound.add(node.name)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            bound |= _param_names(node.args)
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            bound |= {a.asname or a.name.split(".")[0] for a in node.names}
+    return bound
+
+
+def _inject_test_imports(tests: str) -> tuple[str, int]:
+    """Tests with missing whitelisted imports prepended, and the count."""
+    try:
+        tree = ast.parse(tests)
+    except SyntaxError:
+        return tests, 0
+    loaded = {
+        n.id
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)
+    }
+    unbound = loaded - _bound_names(tree) - _BUILTIN_NAMES
+    missing = sorted(unbound & _INJECTABLE_MODULES)
+    if not missing:
+        return tests, 0
+    prelude = "\n".join(f"import {name}" for name in missing)
+    return f"{prelude}\n\n{tests}", len(missing)
 
 
 def _from_dependencies(envelope: dict[str, object]) -> dict[str, object] | None:
@@ -290,6 +357,7 @@ def main() -> None:
     code = str(data.get("code", ""))
     tests = str(data.get("tests", ""))
     tests, tests_sanitized = _sanitize_tests(tests)
+    tests, tests_imports_injected = _inject_test_imports(tests)
     raw_workspace = data.get("workspace")
     workspace = (
         {str(k): str(v) for k, v in raw_workspace.items()}
@@ -310,6 +378,7 @@ def main() -> None:
                 "tests_pass": tests_pass,
                 "n_tests": n_tests,
                 "tests_sanitized": tests_sanitized,
+                "tests_imports_injected": tests_imports_injected,
                 "report": report,
             }
         )

--- a/.llm-orc/scripts/agentic_serving/accept_executor.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor.py
@@ -78,8 +78,19 @@ def _sanitize_tests(tests: str) -> tuple[str, int]:
 # outside the whitelist stay uninjected and reject honestly.
 _INJECTABLE_MODULES = frozenset(
     {
-        "collections", "functools", "itertools", "json", "math", "os",
-        "pathlib", "pytest", "re", "string", "sys", "tempfile", "time",
+        "collections",
+        "functools",
+        "itertools",
+        "json",
+        "math",
+        "os",
+        "pathlib",
+        "pytest",
+        "re",
+        "string",
+        "sys",
+        "tempfile",
+        "time",
         "unittest",
     }
 )

--- a/.llm-orc/scripts/agentic_serving/accept_executor.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor.py
@@ -45,12 +45,22 @@ _MAX_ISOLATED_TESTS = 20
 # tests are the sanitized suite. ``assert result`` on an assigned local is
 # a real truthiness check and is kept.
 _BARE_ASSERT_RE = re.compile(r"^\s*assert\s+([A-Za-z_]\w*)\s*(?:,.*)?$")
-_ASSIGNED_NAME_RE = re.compile(r"^\s*([A-Za-z_]\w*)\s*=[^=]", re.MULTILINE)
 
 
 def _sanitize_tests(tests: str) -> tuple[str, int]:
-    """Tests with value-free bare-name assert lines removed, and the count."""
-    assigned = set(_ASSIGNED_NAME_RE.findall(tests))
+    """Tests with value-free bare-name assert lines removed, and the count.
+
+    "Assigned" is computed via the AST (``_bound_names``): every
+    Store-context name, for/with/walrus target, parameter, def/class name,
+    and import alias — not just a plain ``name = ...`` line — so a bare
+    assert on any of those is a real check, not a value-free reference.
+    Unparseable tests skip sanitization entirely (mirrors the injector).
+    """
+    try:
+        tree = ast.parse(tests)
+    except SyntaxError:
+        return tests, 0
+    assigned = _bound_names(tree)
     kept: list[str] = []
     dropped = 0
     # Skip Python keywords and built-in constants that are intentionally asserted
@@ -127,18 +137,28 @@ def _bound_names(tree: ast.Module) -> set[str]:
     return bound
 
 
-def _inject_test_imports(tests: str) -> tuple[str, int]:
-    """Tests with missing whitelisted imports prepended, and the count."""
+def _inject_test_imports(tests: str, code: str) -> tuple[str, int]:
+    """Tests with missing whitelisted imports prepended, and the count.
+
+    Injection candidates exclude any name the code binds — an injected
+    ``import os`` must never shadow a code-defined ``os`` in the runner's
+    shared namespace, or a code bug (``os = None``) would be masked
+    instead of failing its test.
+    """
     try:
         tree = ast.parse(tests)
     except SyntaxError:
         return tests, 0
+    try:
+        code_bound = _bound_names(ast.parse(code))
+    except SyntaxError:
+        code_bound = set()
     loaded = {
         n.id
         for n in ast.walk(tree)
         if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)
     }
-    unbound = loaded - _bound_names(tree) - _BUILTIN_NAMES
+    unbound = loaded - _bound_names(tree) - _BUILTIN_NAMES - code_bound
     missing = sorted(unbound & _INJECTABLE_MODULES)
     if not missing:
         return tests, 0
@@ -211,17 +231,36 @@ def _aggregate_budget() -> float:
 
 def _enumerate_tests(tests: str) -> tuple[list[str], bool] | None:
     """(top-level test_* function names, has_testcase_classes), or ``None``
-    when the tests don't parse — the caller falls back to one legacy run."""
+    when the tests don't parse — the caller falls back to one legacy run.
+
+    Completeness invariant: per-test isolation only ever runs the names
+    returned here, but only ``tree.body`` is visible to the caller's child
+    dispatch. A ``test_*`` def nested anywhere else (module-level if/try/
+    for, or inside another def) would therefore be silently dropped from
+    the run — legacy's single whole-module exec picks it up regardless of
+    nesting. So if any such nested test def exists, return ``None`` and
+    let the caller fall back to that legacy run instead of losing it.
+    """
     try:
         tree = ast.parse(tests)
     except SyntaxError:
         return None
-    names = [
-        n.name
+    top_level_defs = [
+        n
         for n in tree.body
         if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
         and n.name.startswith("test_")
     ]
+    top_level_ids = {id(n) for n in top_level_defs}
+    nested_exists = any(
+        isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name.startswith("test_")
+        and id(n) not in top_level_ids
+        for n in ast.walk(tree)
+    )
+    if nested_exists:
+        return None
+    names = [n.name for n in top_level_defs]
     has_cases = any(isinstance(n, ast.ClassDef) for n in tree.body)
     return names, has_cases
 
@@ -300,7 +339,9 @@ def _run_children(
     wall budget across the suite is spent — the per-child timeout bounds
     one runaway test, this bounds the whole suite (review finding: 21
     children × per-child timeout is too much blocking time for an
-    interactive serve)."""
+    interactive serve). The budget check happens before spawning each
+    child, not after, so the real worst case is budget + at most one
+    per-child timeout (check-before-spawn slack), not the budget alone."""
     budget = _aggregate_budget()
     start = time.monotonic()
     n = len(children)
@@ -368,7 +409,7 @@ def main() -> None:
     code = str(data.get("code", ""))
     tests = str(data.get("tests", ""))
     tests, tests_sanitized = _sanitize_tests(tests)
-    tests, tests_imports_injected = _inject_test_imports(tests)
+    tests, tests_imports_injected = _inject_test_imports(tests, code)
     raw_workspace = data.get("workspace")
     workspace = (
         {str(k): str(v) for k, v in raw_workspace.items()}

--- a/.llm-orc/scripts/agentic_serving/accept_executor.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import ast
 import json
+import keyword
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -33,6 +35,37 @@ DEFAULT_TIMEOUT = 15.0
 # module globals and written files cannot leak across tests. Bounded and
 # surfaced — no silent caps.
 _MAX_ISOLATED_TESTS = 20
+
+# A bare-name assert on a name the tests never assign (``assert load`` /
+# ``assert load, "msg"``) checks only module-object truthiness — a defined
+# function is always truthy, so the line carries no test value, and the
+# 4-arm tier spike (2026-07-09) showed no seat at any tier/thinking mode
+# satisfies a garbage one. Stripped before execution; the echoed (shipped)
+# tests are the sanitized suite. ``assert result`` on an assigned local is
+# a real truthiness check and is kept.
+_BARE_ASSERT_RE = re.compile(r"^\s*assert\s+([A-Za-z_]\w*)\s*(?:,.*)?$")
+_ASSIGNED_NAME_RE = re.compile(r"^\s*([A-Za-z_]\w*)\s*=[^=]", re.MULTILINE)
+
+
+def _sanitize_tests(tests: str) -> tuple[str, int]:
+    """Tests with value-free bare-name assert lines removed, and the count."""
+    assigned = set(_ASSIGNED_NAME_RE.findall(tests))
+    kept: list[str] = []
+    dropped = 0
+    # Skip Python keywords and built-in constants that are intentionally asserted
+    skip_names = {"True", "False", "None", "__name__", "__doc__"}
+    for line in tests.splitlines():
+        match = _BARE_ASSERT_RE.match(line)
+        if (
+            match
+            and match.group(1) not in assigned
+            and not keyword.iskeyword(match.group(1))
+            and match.group(1) not in skip_names
+        ):
+            dropped += 1
+            continue
+        kept.append(line)
+    return "\n".join(kept) + ("\n" if tests.endswith("\n") else ""), dropped
 
 
 def _from_dependencies(envelope: dict[str, object]) -> dict[str, object] | None:
@@ -256,6 +289,7 @@ def main() -> None:
     requirement = str(data.get("requirement", ""))
     code = str(data.get("code", ""))
     tests = str(data.get("tests", ""))
+    tests, tests_sanitized = _sanitize_tests(tests)
     raw_workspace = data.get("workspace")
     workspace = (
         {str(k): str(v) for k, v in raw_workspace.items()}
@@ -275,6 +309,7 @@ def main() -> None:
                 "tests": tests,
                 "tests_pass": tests_pass,
                 "n_tests": n_tests,
+                "tests_sanitized": tests_sanitized,
                 "report": report,
             }
         )

--- a/.llm-orc/scripts/agentic_serving/accept_executor.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor.py
@@ -16,8 +16,10 @@ the contract and artifact to the isolated judge seat.
 
 from __future__ import annotations
 
+import ast
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -25,6 +27,12 @@ from pathlib import Path
 
 RUNNER = Path(__file__).with_name("accept_executor_runner.py")
 DEFAULT_TIMEOUT = 15.0
+
+# per-test isolation (seat-quality design 2026-07-09): each test function
+# runs in its own subprocess with its own fresh materialized directory, so
+# module globals and written files cannot leak across tests. Bounded and
+# surfaced — no silent caps.
+_MAX_ISOLATED_TESTS = 20
 
 
 def _from_dependencies(envelope: dict[str, object]) -> dict[str, object] | None:
@@ -73,32 +81,63 @@ def _timeout() -> float:
         return DEFAULT_TIMEOUT
 
 
-def _run_sandboxed(
+def _enumerate_tests(tests: str) -> tuple[list[str], bool] | None:
+    """(top-level test_* function names, has_testcase_classes), or ``None``
+    when the tests don't parse — the caller falls back to one legacy run."""
+    try:
+        tree = ast.parse(tests)
+    except SyntaxError:
+        return None
+    names = [
+        n.name
+        for n in tree.body
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name.startswith("test_")
+    ]
+    has_cases = any(isinstance(n, ast.ClassDef) for n in tree.body)
+    return names, has_cases
+
+
+def _materialize(
+    tmp: str,
     code: str,
     tests: str,
-    workspace: dict[str, str] | None = None,
-    target_file: str = "",
+    workspace: dict[str, str] | None,
+    target_file: str,
+) -> tuple[Path, Path]:
+    """Write one child's fresh sandbox dir: conversation-written workspace
+    files, then the edit turn's target-file shadow, then solution.py and
+    tests.py — exactly the materialization the legacy single run did."""
+    for name, body in (workspace or {}).items():
+        safe = Path(name).name
+        if safe and safe not in ("solution.py", "tests.py"):
+            (Path(tmp) / safe).write_text(str(body), encoding="utf-8")
+    safe_target = Path(target_file).name if target_file else ""
+    if safe_target and safe_target not in ("solution.py", "tests.py"):
+        (Path(tmp) / safe_target).write_text(code, encoding="utf-8")
+    code_path = Path(tmp) / "solution.py"
+    tests_path = Path(tmp) / "tests.py"
+    code_path.write_text(code, encoding="utf-8")
+    tests_path.write_text(tests, encoding="utf-8")
+    return code_path, tests_path
+
+
+def _run_one(
+    code: str,
+    tests: str,
+    workspace: dict[str, str] | None,
+    target_file: str,
+    only: str | None,
+    timeout: float,
 ) -> tuple[bool, str, int]:
-    timeout = _timeout()
     with tempfile.TemporaryDirectory() as tmp:
-        # conversation-written files (gather's workspace) so tests can import
-        # modules the conversation built; basenames only, no path traversal
-        for name, body in (workspace or {}).items():
-            safe = Path(name).name
-            if safe and safe not in ("solution.py", "tests.py"):
-                (Path(tmp) / safe).write_text(str(body), encoding="utf-8")
-        # an edit turn's deliverable shadows the stale workspace copy at its
-        # destination — mirroring what the client's write will do on accept
-        safe_target = Path(target_file).name if target_file else ""
-        if safe_target and safe_target not in ("solution.py", "tests.py"):
-            (Path(tmp) / safe_target).write_text(code, encoding="utf-8")
-        code_path = Path(tmp) / "solution.py"
-        tests_path = Path(tmp) / "tests.py"
-        code_path.write_text(code, encoding="utf-8")
-        tests_path.write_text(tests, encoding="utf-8")
+        code_path, tests_path = _materialize(tmp, code, tests, workspace, target_file)
+        argv = [sys.executable, str(RUNNER), str(code_path), str(tests_path)]
+        if only is not None:
+            argv += ["--only", only]
         try:
             completed = subprocess.run(
-                [sys.executable, str(RUNNER), str(code_path), str(tests_path)],
+                argv,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
@@ -119,6 +158,43 @@ def _run_sandboxed(
         str(verdict.get("report", "")),
         int(verdict.get("n_tests", 0)),
     )
+
+
+def _run_sandboxed(
+    code: str,
+    tests: str,
+    workspace: dict[str, str] | None = None,
+    target_file: str = "",
+) -> tuple[bool, str, int]:
+    timeout = _timeout()
+    enumerated = _enumerate_tests(tests)
+    if enumerated is None or (not enumerated[0] and not enumerated[1]):
+        # unparseable or nothing enumerable: one legacy run reports it
+        return _run_one(code, tests, workspace, target_file, None, timeout)
+
+    names, has_cases = enumerated
+    capped = len(names) > _MAX_ISOLATED_TESTS
+    children: list[str | None] = list(names[:_MAX_ISOLATED_TESTS])
+    if has_cases:
+        children.append("__cases__")
+
+    failures: list[str] = []
+    total = 0
+    for only in children:
+        ok, report, n_tests = _run_one(
+            code, tests, workspace, target_file, only, timeout
+        )
+        total += n_tests
+        if not ok:
+            failures.append(report)
+    if capped:
+        failures.append(f"…capped at {_MAX_ISOLATED_TESTS} isolated tests")
+
+    # a load failure repeats identically in every child — report it once
+    deduped = list(dict.fromkeys(failures))
+    if deduped:
+        return False, "; ".join(deduped), total
+    return True, "all passed", total
 
 
 def main() -> None:

--- a/.llm-orc/scripts/agentic_serving/accept_executor.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor.py
@@ -19,10 +19,10 @@ from __future__ import annotations
 import ast
 import json
 import os
-import re
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 RUNNER = Path(__file__).with_name("accept_executor_runner.py")
@@ -79,6 +79,23 @@ def _timeout() -> float:
         return float(raw) if raw else DEFAULT_TIMEOUT
     except ValueError:
         return DEFAULT_TIMEOUT
+
+
+_BUDGET_MULTIPLIER = 3.0
+
+
+def _aggregate_budget() -> float:
+    """Total wall budget across isolated children: per-child timeout × 3
+    by default, LLM_ORC_ACCEPT_EXECUTOR_BUDGET overrides (seconds). The
+    per-child timeout bounds one runaway test; this bounds the SUITE —
+    per-test isolation multiplied the old single-run bound by the child
+    count, and an interactive serve cannot absorb 21× (review finding,
+    seat-quality arc 2026-07-09)."""
+    raw = os.environ.get("LLM_ORC_ACCEPT_EXECUTOR_BUDGET", "")
+    try:
+        return float(raw) if raw else _timeout() * _BUDGET_MULTIPLIER
+    except ValueError:
+        return _timeout() * _BUDGET_MULTIPLIER
 
 
 def _enumerate_tests(tests: str) -> tuple[list[str], bool] | None:
@@ -160,6 +177,41 @@ def _run_one(
     )
 
 
+def _run_children(
+    code: str,
+    tests: str,
+    workspace: dict[str, str] | None,
+    target_file: str,
+    timeout: float,
+    children: list[str | None],
+) -> tuple[list[str], int]:
+    """Run each isolated child in turn, stopping early once the aggregate
+    wall budget across the suite is spent — the per-child timeout bounds
+    one runaway test, this bounds the whole suite (review finding: 21
+    children × per-child timeout is too much blocking time for an
+    interactive serve)."""
+    budget = _aggregate_budget()
+    start = time.monotonic()
+    n = len(children)
+    failures: list[str] = []
+    total = 0
+    for i, only in enumerate(children):
+        if time.monotonic() - start >= budget:
+            remaining = n - i
+            failures.append(
+                f"aggregate budget exhausted after {budget:g}s; "
+                f"{remaining} of {n} tests not run"
+            )
+            break
+        ok, report, n_tests = _run_one(
+            code, tests, workspace, target_file, only, timeout
+        )
+        total += n_tests
+        if not ok:
+            failures.append(report)
+    return failures, total
+
+
 def _run_sandboxed(
     code: str,
     tests: str,
@@ -178,15 +230,9 @@ def _run_sandboxed(
     if has_cases:
         children.append("__cases__")
 
-    failures: list[str] = []
-    total = 0
-    for only in children:
-        ok, report, n_tests = _run_one(
-            code, tests, workspace, target_file, only, timeout
-        )
-        total += n_tests
-        if not ok:
-            failures.append(report)
+    failures, total = _run_children(
+        code, tests, workspace, target_file, timeout, children
+    )
     if capped:
         failures.append(f"…capped at {_MAX_ISOLATED_TESTS} isolated tests")
 

--- a/.llm-orc/scripts/agentic_serving/accept_executor_runner.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor_runner.py
@@ -3,9 +3,11 @@
 
 Runs the produced tests against the produced code in a fresh subprocess, so a
 runaway or crashing test cannot hang the serve. Invoked by ``accept_executor.py``
-as ``python accept_executor_runner.py <code_path> <tests_path>``: reads the two
-files, execs them in one shared namespace (so the tests reference the code's
-names), runs every ``test_*`` callable, and prints the deterministic verdict.
+as ``python accept_executor_runner.py <code_path> <tests_path> [--only <name>]``:
+reads the two files, execs them in one shared namespace (so the tests reference
+the code's names), runs every ``test_*`` callable, and prints the deterministic
+verdict. Optional ``--only <name>`` runs a single test function by name;
+``--only __cases__`` runs only unittest.TestCase classes.
 
 Emits JSON: {tests_pass, n_tests, report}
 
@@ -22,6 +24,18 @@ import traceback
 from pathlib import Path
 
 
+def _filter_by_only(
+    test_fns: list, case_classes: list, only: str | None
+) -> tuple[list, list]:
+    """Restrict the run per --only: a named test_* function (TestCase
+    classes skipped), or "__cases__" for just the TestCase classes."""
+    if only == "__cases__":
+        return [], case_classes
+    if only is not None:
+        return [(n, f) for n, f in test_fns if n == only], []
+    return test_fns, case_classes
+
+
 def _failing_line(error: Exception, tests: str) -> str:
     """The failing source line from the tests, when the last traceback frame
     lands there — a bare 'AssertionError()' gives the retry round nothing to
@@ -36,6 +50,29 @@ def _failing_line(error: Exception, tests: str) -> str:
             if 0 < frame.lineno <= len(lines):
                 return lines[frame.lineno - 1].strip()
     return ""
+
+
+def _run_test_fns(test_fns: list, tests: str) -> tuple[int, list[str]]:
+    """Execute each test_* function; return count and failures list."""
+    import asyncio
+
+    n_tests = 0
+    failures: list[str] = []
+    for name, fn in test_fns:
+        n_tests += 1
+        try:
+            result = fn()
+            if asyncio.iscoroutine(result):
+                # an async test returns a coroutine that raised nothing yet —
+                # uncollected it would count as a silent pass (wrong accept)
+                asyncio.run(result)
+        except Exception as error:  # noqa: BLE001
+            line = _failing_line(error, tests)
+            detail = f"{name}: {error!r}"
+            if line:
+                detail += f" at: {line}"
+            failures.append(detail)
+    return n_tests, failures
 
 
 def run_tests(code: str, tests: str, only: str | None = None) -> tuple[bool, str, int]:
@@ -74,31 +111,9 @@ def run_tests(code: str, tests: str, only: str | None = None) -> tuple[bool, str
         and obj is not unittest.TestCase
     ]
 
-    if only == "__cases__":
-        test_fns = []
-    elif only is not None:
-        test_fns = [(n, f) for n, f in test_fns if n == only]
-        case_classes = []
+    test_fns, case_classes = _filter_by_only(test_fns, case_classes, only)
 
-    failures: list[str] = []
-    n_tests = 0
-
-    import asyncio
-
-    for name, fn in test_fns:
-        n_tests += 1
-        try:
-            result = fn()
-            if asyncio.iscoroutine(result):
-                # an async test returns a coroutine that raised nothing yet —
-                # uncollected it would count as a silent pass (wrong accept)
-                asyncio.run(result)
-        except Exception as error:  # noqa: BLE001
-            line = _failing_line(error, tests)
-            detail = f"{name}: {error!r}"
-            if line:
-                detail += f" at: {line}"
-            failures.append(detail)
+    n_tests, failures = _run_test_fns(test_fns, tests)
 
     if case_classes:
         loader = unittest.defaultTestLoader
@@ -112,8 +127,10 @@ def run_tests(code: str, tests: str, only: str | None = None) -> tuple[bool, str
             failures.append(f"{test}: {trace.strip().splitlines()[-1]}")
 
     if n_tests == 0:
-        detail = f"no test named {only!r} found" if only and only != "__cases__" else (
-            "no test_* functions or TestCase classes found"
+        detail = (
+            f"no test named {only!r} found"
+            if only and only != "__cases__"
+            else ("no test_* functions or TestCase classes found")
         )
         return False, detail, 0
     if failures:

--- a/.llm-orc/scripts/agentic_serving/accept_executor_runner.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor_runner.py
@@ -38,8 +38,14 @@ def _failing_line(error: Exception, tests: str) -> str:
     return ""
 
 
-def run_tests(code: str, tests: str) -> tuple[bool, str, int]:
-    """Exec code + tests in a shared namespace, call every ``test_*`` function."""
+def run_tests(code: str, tests: str, only: str | None = None) -> tuple[bool, str, int]:
+    """Exec code + tests in a shared namespace, call every ``test_*`` function.
+
+    ``only`` (per-test isolation, seat-quality design 2026-07-09) restricts
+    the run to one named top-level test function — the executor spawns one
+    runner per test so module and filesystem state cannot leak across
+    tests. ``only="__cases__"`` runs just the unittest.TestCase classes.
+    """
     namespace: dict[str, object] = {}
     try:
         exec(compile(code, "solution.py", "exec"), namespace)
@@ -67,6 +73,12 @@ def run_tests(code: str, tests: str) -> tuple[bool, str, int]:
         and issubclass(obj, unittest.TestCase)
         and obj is not unittest.TestCase
     ]
+
+    if only == "__cases__":
+        test_fns = []
+    elif only is not None:
+        test_fns = [(n, f) for n, f in test_fns if n == only]
+        case_classes = []
 
     failures: list[str] = []
     n_tests = 0
@@ -100,7 +112,10 @@ def run_tests(code: str, tests: str) -> tuple[bool, str, int]:
             failures.append(f"{test}: {trace.strip().splitlines()[-1]}")
 
     if n_tests == 0:
-        return False, "no test_* functions or TestCase classes found", 0
+        detail = f"no test named {only!r} found" if only and only != "__cases__" else (
+            "no test_* functions or TestCase classes found"
+        )
+        return False, detail, 0
     if failures:
         return False, "; ".join(failures), n_tests
     return True, "all passed", n_tests
@@ -110,9 +125,12 @@ def main() -> None:
     # sandbox dir on sys.path so tests can import materialized workspace
     # modules (conversation-written files) as siblings
     sys.path.insert(0, str(Path(sys.argv[1]).resolve().parent))
+    only = None
+    if "--only" in sys.argv:
+        only = sys.argv[sys.argv.index("--only") + 1]
     code = Path(sys.argv[1]).read_text(encoding="utf-8")
     tests = Path(sys.argv[2]).read_text(encoding="utf-8")
-    tests_pass, report, n_tests = run_tests(code, tests)
+    tests_pass, report, n_tests = run_tests(code, tests, only)
     print(json.dumps({"tests_pass": tests_pass, "n_tests": n_tests, "report": report}))
 
 

--- a/.llm-orc/scripts/agentic_serving/classify.py
+++ b/.llm-orc/scripts/agentic_serving/classify.py
@@ -43,8 +43,14 @@ _EXPLAIN_MARKERS = (
 )
 # An interrogative-shaped turn asks for understanding; it outranks the
 # named-file build signal ("What approach does palindrome.py use?" is an
-# explain turn, not a build).
-_INTERROGATIVE_RE = re.compile(r"^(what|why|how|when|where|which|who)\b", re.IGNORECASE)
+# explain turn, not a build). The yes/no forms are deliberately narrow —
+# only memory-shaped questions addressed to the assistant ("did you…",
+# "have you…"); "can/could/will you write X" are polite imperatives and
+# must stay on the build path (ladder turn 5 mis-route, 2026-07-09).
+_INTERROGATIVE_RE = re.compile(
+    r"^(?:what|why|how|when|where|which|who)\b|^(?:did|have) you\b",
+    re.IGNORECASE,
+)
 _DEFAULT_CODE_SEAT = "code-seat"
 _EXPLAIN_SEAT = "explainer"
 _TESTS_SEAT = "tests-seat"

--- a/docs/plans/2026-07-09-seat-quality-isolation-escalation-design.md
+++ b/docs/plans/2026-07-09-seat-quality-isolation-escalation-design.md
@@ -91,6 +91,19 @@ conversion, ~1/10 the latency), via the existing
 class converts under escalation that isolation + the sanitizer don't
 already fix. Loop bound stays 2.
 
+### Slice 3 — missing-import injection (amendment, live-evidence 2026-07-09)
+
+Task 5's regression probe surfaced a fourth class: the 8b's tests call
+`os.path.exists` / `pytest.raises` without importing `os`/`pytest`, so
+every round NameErrors on a defect no code regeneration can fix (code
+cannot define `pytest`). Deterministic repair, same shape as the existing
+workspace-import injection: AST-collect unbound names in the tests,
+intersect a fixed whitelist (`os, json, sys, re, math, time, pathlib,
+tempfile, itertools, functools, collections, string, unittest, pytest`),
+prepend the `import` lines before execution. The echoed (shipped) tests
+carry the injected imports — the artifact becomes self-contained. Names
+outside the whitelist stay uninjected and reject honestly.
+
 ## Validation
 
 - Per-slice TDD; hermetic runs through the real engine for the router

--- a/docs/plans/2026-07-09-seat-quality-isolation-escalation-design.md
+++ b/docs/plans/2026-07-09-seat-quality-isolation-escalation-design.md
@@ -1,0 +1,96 @@
+# Seat quality: per-test isolation, then bounded escalation (path item 4)
+
+**Status:** Approved design, 2026-07-09. Follows the v0.18.6 ladder rerun
+(4/10 strict; 3 misses from round-1 test quality).
+
+## Evidence (live probes, 2026-07-09, qwen3:8b seats)
+
+Two fresh single-turn probes reproduced the ladder's build rejects 2/2,
+with full traces (`LLM_ORC_SERVE_TRACE_SNIPPET=6000`):
+
+- **"write a function that adds a todo item to a list in todo.py"** —
+  round 1: tests call `add`, code named it differently (`NameError`).
+  Round 2 (held tests) defined `add` correctly and STILL rejected:
+  `test_add_multiple_todo_items` asserts `len(todos) == 2` after an
+  earlier test already appended — module-global state leaking across
+  tests in one run.
+- **"create storage.py with save_todos and load_todos using json"** —
+  round 1 tests assert `not os.path.exists("todos.json")` after an
+  earlier test created it (filesystem leakage), plus round 2 regenerated
+  `load` where the failure report explicitly named `load_todos` missing.
+
+Failure classes:
+
+- **A — test-order state leakage** (both probes; the dominant breaker):
+  the 8b writes tests that assume per-test isolation the executor does
+  not provide. The code was right; the gate false-rejected. Deterministic
+  executor fix available — no model judgment involved.
+- **B — name divergence surviving the held round** (one probe): the seat
+  ignored an explicitly named missing symbol on the retry. Third
+  confirmation of the prompt-saturation finding → structural lever
+  (escalation), not another prompt rule.
+- **C — exception-message assertions** (known #98 residual): present in
+  probe tests but not the breaking failure. No sanitizer this arc; revisit
+  when it breaks a measured turn.
+
+## Slices
+
+### Slice 0 — decider interrogative fix
+
+`_INTERROGATIVE_RE` (classify) covers wh-forms only, so "did you see my
+previous query?" rides the stochastic decider (ladder turn 5 mis-routed to
+build). Add the memory-shaped yes/no form addressed to the assistant:
+`^(did|have) you\b`. Deliberately NOT `can/could/will/would you` — polite
+imperatives ("can you write add.py?") must stay on the build path.
+
+### Slice 1 — per-test isolation in the accept executor
+
+Today the executor materializes `solution.py` + `tests.py` + workspace
+into one tempdir and runs one subprocess; module globals and written
+files leak across test functions. Change: **each test function runs in
+its own subprocess with its own fresh copy of the materialized
+workspace** (fresh import, fresh cwd). Chosen over a single-subprocess
+re-import loop because interpreter state (env mutations, monkey-patched
+modules) would still leak there, and the overhead (~100ms × ≤10 tests)
+is trivial on the rig.
+
+- The line-level failure report keeps its format, aggregated per test.
+- Collection errors and the deterministic adequacy checker are untouched.
+- Both build-gated and write-tests shapes inherit the change (shared
+  executor).
+- Tests that genuinely require cross-test ordering now pass individually —
+  acceptable; order-independence is the intended test semantics.
+
+### Slice 2 — round-3 escalation on exhausted retry
+
+`route_round` (the deterministic router) gains one rung: a reject whose
+held 8b retry also rejected dispatches ONE round 3 to `build-code-round`
+on a new **`agentic-tier-strong`** profile — shipped default
+**`qwen3:14b`** (local, fits the 32GB rig; operator-overridable via
+`*.local.yaml` like every tier). Same held tests, same gate; after round
+3, honest reject as today. Loop bound 2 → 3; the turn trace records the
+escalated round. Code seat only — test-writer escalation is class C
+territory, out of this arc.
+
+## Validation
+
+- Per-slice TDD; hermetic runs through the real engine for the router
+  bound and the executor isolation.
+- The two probe prompts above are the live regression fixtures. Probe 1
+  must ACCEPT after slice 1 alone (its held-round code was right; only
+  test interference rejected it). Probe 2 clears its leakage failures
+  under slice 1 but its name divergence (class B) persists — it must
+  ACCEPT after slices 1+2 together (stochastic seat caveat: "accept
+  within two attempts" is the pass bar for both).
+- Full ladder rerun (`benchmarks/agentic_serving/ladder_battery.sh`),
+  new trajectory row.
+- Record the arc's measurement: how many rejects survive isolation, and
+  of those, how many round-3 14b converts.
+
+## Out of scope
+
+- Test sanitizer for exception-message assertions (class C) — deferred
+  until it breaks a measured turn.
+- Test-writer seat escalation.
+- #83 run half (client-delegated execution, discovery) — next arc, per
+  roadmap.

--- a/docs/plans/2026-07-09-seat-quality-isolation-escalation-design.md
+++ b/docs/plans/2026-07-09-seat-quality-isolation-escalation-design.md
@@ -1,7 +1,8 @@
-# Seat quality: per-test isolation, then bounded escalation (path item 4)
+# Seat quality: per-test isolation + bare-name-assert sanitizer (path item 4)
 
-**Status:** Approved design, 2026-07-09. Follows the v0.18.6 ladder rerun
-(4/10 strict; 3 misses from round-1 test quality).
+**Status:** Approved design, 2026-07-09 (rev 2 — escalation deferred on
+spike data). Follows the v0.18.6 ladder rerun (4/10 strict; 3 misses from
+round-1 test quality).
 
 ## Evidence (live probes, 2026-07-09, qwen3:8b seats)
 
@@ -61,16 +62,34 @@ is trivial on the rig.
 - Tests that genuinely require cross-test ordering now pass individually —
   acceptable; order-independence is the intended test semantics.
 
-### Slice 2 — round-3 escalation on exhausted retry
+### Slice 2′ — bare-name-assert sanitizer (replaces escalation; spike-grounded)
 
-`route_round` (the deterministic router) gains one rung: a reject whose
-held 8b retry also rejected dispatches ONE round 3 to `build-code-round`
-on a new **`agentic-tier-strong`** profile — shipped default
-**`qwen3:14b`** (local, fits the 32GB rig; operator-overridable via
-`*.local.yaml` like every tier). Same held tests, same gate; after round
-3, honest reject as today. Loop bound 2 → 3; the turn trace records the
-escalated round. Code seat only — test-writer escalation is class C
-territory, out of this arc.
+The 4-arm tier/thinking spike (2026-07-09, probe-2 held-round fixture,
+n=3 per arm) found every arm — {qwen3:8b, qwen3:14b} × {think on, off} —
+defines the required API and plateaus at exactly 3/4 held tests. The
+universal failure is the suite's stray `assert load` line: a value-free,
+bare-name assert referencing a symbol every model reads as a typo for
+`load_todos`. No tier or thinking mode converts a garbage test line.
+
+So the residual lever is deterministic: **strip `assert <bare-name>`
+statements from authored/held tests before execution** — an assert whose
+test expression is a bare `Name` node checks only object truthiness (a
+defined function is always truthy) and carries no test value. One small
+AST pass applied where tests are gathered for the executor; the shipped
+artifact carries the sanitized suite (what executed is what ships,
+preserving the #98 invariant). With it, the fixture accepts at round 1
+on the cheap seat in ~5s.
+
+### Escalation — deferred, measurement recorded
+
+Spike latency data: qwen3:14b think-off generates as fast as qwen3:8b
+think-off on this rig (4–13s vs 5–9s); think-on costs 10–20× wall on
+either model (52–105s). **If a measured class ever demands escalation,
+the rung is qwen3:14b think-off** (dominates 8b think-on: same
+conversion, ~1/10 the latency), via the existing
+`agentic-tier-escalated-general` profile. Not built now: no measured
+class converts under escalation that isolation + the sanitizer don't
+already fix. Loop bound stays 2.
 
 ## Validation
 
@@ -78,19 +97,21 @@ territory, out of this arc.
   bound and the executor isolation.
 - The two probe prompts above are the live regression fixtures. Probe 1
   must ACCEPT after slice 1 alone (its held-round code was right; only
-  test interference rejected it). Probe 2 clears its leakage failures
-  under slice 1 but its name divergence (class B) persists — it must
-  ACCEPT after slices 1+2 together (stochastic seat caveat: "accept
-  within two attempts" is the pass bar for both).
+  test interference rejected it). Probe 2 must ACCEPT after slices 1+2′
+  together (isolation clears the leakage asserts; the sanitizer clears
+  the stray `assert load`). Stochastic seat caveat: "accept within two
+  attempts" is the pass bar for both.
 - Full ladder rerun (`benchmarks/agentic_serving/ladder_battery.sh`),
   new trajectory row.
-- Record the arc's measurement: how many rejects survive isolation, and
-  of those, how many round-3 14b converts.
+- Record the arc's measurement: how many ladder rejects survive
+  isolation + the sanitizer.
 
 ## Out of scope
 
-- Test sanitizer for exception-message assertions (class C) — deferred
-  until it breaks a measured turn.
+- Escalation (deferred with its measurement — see above).
+- Sanitizing exception-message assertions (the other #98 residual) —
+  deferred until it breaks a measured turn; the sanitizer's boundary is
+  bare-name asserts only.
 - Test-writer seat escalation.
 - #83 run half (client-delegated execution, discovery) — next arc, per
   roadmap.

--- a/docs/plans/2026-07-09-seat-quality-plan.md
+++ b/docs/plans/2026-07-09-seat-quality-plan.md
@@ -1,0 +1,568 @@
+# Seat Quality Implementation Plan (path item 4: isolation + sanitizer)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Kill the measured round-1 false-reject classes deterministically — per-test isolation in the accept executor, a bare-name-assert sanitizer, and the classify interrogative fix.
+
+**Architecture:** Three independent deterministic changes, no model judgment added. classify gains a memory-shaped interrogative form. The accept executor enumerates test functions via AST and runs each in its own subprocess with its own fresh materialized directory (module and filesystem state cannot leak across tests), reusing the existing runner with a new `--only` flag. Before execution the executor strips value-free bare-name assert lines from the tests and echoes the sanitized suite (what executes is what ships).
+
+**Tech Stack:** Python 3.13, pytest, subprocess-driven script tests (the established `tests/unit/serving/` pattern).
+
+**Spec:** `docs/plans/2026-07-09-seat-quality-isolation-escalation-design.md`
+
+## Global Constraints
+
+- ruff (88 chars) and mypy strict compliant from first draft for `src/`/`tests/`; scripts under `.llm-orc/scripts/` match their existing style. `make lint` before every commit.
+- TDD: failing test → verify fail → implement → verify pass → commit. One behavioral unit per commit; prefixes `feat:`/`fix:`/`test:`/`docs:`. No AI attribution.
+- No silent caps: any bound the executor applies (child cap) must surface in the report text.
+- Escalation is OUT of scope (deferred per spec rev 2); loop bound stays 2.
+- Full suite: `make test`. Targeted: `uv run pytest <path> -v`.
+
+---
+
+### Task 1: classify — memory-shaped interrogative routes to explain
+
+**Files:**
+- Modify: `.llm-orc/scripts/agentic_serving/classify.py` (the `_INTERROGATIVE_RE` constant)
+- Test: `tests/unit/serving/test_serving_classify.py`
+
+**Interfaces:**
+- Consumes: existing `_classify(turn)` subprocess helper in the test file.
+- Produces: "did you …" / "have you …" turns route to `explainer` deterministically (no decider).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/serving/test_serving_classify.py`:
+
+```python
+def test_did_you_memory_question_routes_to_explainer_deterministically() -> None:
+    decision = _classify({"task": "did you see my previous query?"})
+    assert decision["target"] == "explainer"
+    assert decision["build"] is False
+    assert decision["needs_decider"] is False
+
+
+def test_have_you_question_routes_to_explainer() -> None:
+    decision = _classify({"task": "have you written any tests yet?"})
+    assert decision["target"] == "explainer"
+
+
+def test_can_you_write_stays_a_build_turn() -> None:
+    decision = _classify({"task": "can you write a function that adds in add.py"})
+    assert decision["target"] != "explainer"
+    assert decision["build"] is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/serving/test_serving_classify.py -v`
+Expected: the two new explainer tests FAIL (`needs_decider` True / wrong target); `can_you` may already pass (keep as a regression guard).
+
+- [ ] **Step 3: Implement**
+
+In `classify.py`, replace the `_INTERROGATIVE_RE` definition:
+
+```python
+# An interrogative-shaped turn asks for understanding; it outranks the
+# named-file build signal ("What approach does palindrome.py use?" is an
+# explain turn, not a build). The yes/no forms are deliberately narrow —
+# only memory-shaped questions addressed to the assistant ("did you…",
+# "have you…"); "can/could/will you write X" are polite imperatives and
+# must stay on the build path (ladder turn 5 mis-route, 2026-07-09).
+_INTERROGATIVE_RE = re.compile(
+    r"^(?:what|why|how|when|where|which|who)\b|^(?:did|have) you\b",
+    re.IGNORECASE,
+)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/serving/test_serving_classify.py -v`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .llm-orc/scripts/agentic_serving/classify.py tests/unit/serving/test_serving_classify.py
+git commit -m "fix: route memory-shaped yes/no questions to explain deterministically"
+```
+
+---
+
+### Task 2: runner — `--only <test_name>` single-test mode
+
+**Files:**
+- Modify: `.llm-orc/scripts/agentic_serving/accept_executor_runner.py`
+- Test: `tests/unit/serving/test_serving_accept_executor_runner.py` (new)
+
+**Interfaces:**
+- Consumes: existing `run_tests(code, tests)` and the CLI form `runner.py <code_path> <tests_path>`.
+- Produces: CLI form `runner.py <code_path> <tests_path> --only <name>` — loads code+tests as today but calls ONLY the named top-level `test_*` function (TestCase classes are skipped in `--only` mode); `--only __cases__` runs ONLY the unittest TestCase classes. No flag = legacy whole-run behavior, byte-identical.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/serving/test_serving_accept_executor_runner.py`:
+
+```python
+"""Single-test mode for the accept-gate runner (per-test isolation,
+seat-quality design 2026-07-09). Driven via subprocess exactly as
+accept_executor.py invokes it."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[3]
+RUNNER = REPO / ".llm-orc" / "scripts" / "agentic_serving" / "accept_executor_runner.py"
+
+CODE = "todos = []\ndef add(item):\n    todos.append(item)\n"
+LEAKY_TESTS = (
+    "def test_one():\n    add('a')\n    assert len(todos) == 1\n"
+    "def test_two():\n    add('a')\n    add('b')\n    assert len(todos) == 2\n"
+)
+
+
+def _run(code: str, tests: str, tmp: Path, only: str | None = None) -> dict[str, Any]:
+    (tmp / "solution.py").write_text(code)
+    (tmp / "tests.py").write_text(tests)
+    argv = [sys.executable, str(RUNNER), str(tmp / "solution.py"), str(tmp / "tests.py")]
+    if only is not None:
+        argv += ["--only", only]
+    out = subprocess.run(argv, capture_output=True, text=True, cwd=tmp, check=True)
+    result: dict[str, Any] = json.loads(out.stdout)
+    return result
+
+
+def test_only_runs_exactly_the_named_test(tmp_path: Path) -> None:
+    verdict = _run(CODE, LEAKY_TESTS, tmp_path, only="test_two")
+    assert verdict["n_tests"] == 1
+    assert verdict["tests_pass"] is True  # fresh namespace: no leaked 'a'
+
+
+def test_only_unknown_name_reports_zero_tests(tmp_path: Path) -> None:
+    verdict = _run(CODE, LEAKY_TESTS, tmp_path, only="test_missing")
+    assert verdict["n_tests"] == 0
+    assert verdict["tests_pass"] is False
+
+
+def test_no_flag_keeps_legacy_whole_run(tmp_path: Path) -> None:
+    verdict = _run(CODE, LEAKY_TESTS, tmp_path)
+    assert verdict["n_tests"] == 2
+    assert verdict["tests_pass"] is False  # the shared-state leak, as today
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/serving/test_serving_accept_executor_runner.py -v`
+Expected: the two `--only` tests FAIL (unknown flag / whole run executes); the legacy test PASSES.
+
+- [ ] **Step 3: Implement**
+
+In `accept_executor_runner.py`:
+
+Add an `only` parameter to `run_tests` and filter both dialects:
+
+```python
+def run_tests(code: str, tests: str, only: str | None = None) -> tuple[bool, str, int]:
+    """Exec code + tests in a shared namespace, call every ``test_*`` function.
+
+    ``only`` (per-test isolation, seat-quality design 2026-07-09) restricts
+    the run to one named top-level test function — the executor spawns one
+    runner per test so module and filesystem state cannot leak across
+    tests. ``only="__cases__"`` runs just the unittest.TestCase classes.
+    """
+```
+
+After `test_fns` and `case_classes` are collected, insert:
+
+```python
+    if only == "__cases__":
+        test_fns = []
+    elif only is not None:
+        test_fns = [(n, f) for n, f in test_fns if n == only]
+        case_classes = []
+```
+
+And in the `n_tests == 0` return, keep the message but make it mode-aware:
+
+```python
+    if n_tests == 0:
+        detail = f"no test named {only!r} found" if only and only != "__cases__" else (
+            "no test_* functions or TestCase classes found"
+        )
+        return False, detail, 0
+```
+
+In `main()`, parse the flag (keep the positional contract):
+
+```python
+def main() -> None:
+    # sandbox dir on sys.path so tests can import materialized workspace
+    # modules (conversation-written files) as siblings
+    sys.path.insert(0, str(Path(sys.argv[1]).resolve().parent))
+    only = None
+    if "--only" in sys.argv:
+        only = sys.argv[sys.argv.index("--only") + 1]
+    code = Path(sys.argv[1]).read_text(encoding="utf-8")
+    tests = Path(sys.argv[2]).read_text(encoding="utf-8")
+    tests_pass, report, n_tests = run_tests(code, tests, only)
+    print(json.dumps({"tests_pass": tests_pass, "n_tests": n_tests, "report": report}))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/serving/test_serving_accept_executor_runner.py tests/unit/serving/test_serving_accept_gate.py -v`
+Expected: ALL PASS (the gate file's legacy executor tests guard the no-flag path).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .llm-orc/scripts/agentic_serving/accept_executor_runner.py tests/unit/serving/test_serving_accept_executor_runner.py
+git commit -m "feat: runner --only mode for per-test isolation"
+```
+
+---
+
+### Task 3: executor — one fresh sandbox per test function
+
+**Files:**
+- Modify: `.llm-orc/scripts/agentic_serving/accept_executor.py`
+- Test: `tests/unit/serving/test_serving_accept_gate.py` (extend; its `_executor` helper drives the script)
+
+**Interfaces:**
+- Consumes: Task 2's `--only` runner mode.
+- Produces: `_run_sandboxed(code, tests, workspace, target_file)` same signature and return `(tests_pass, report, n_tests)`, but internally: AST-enumerate top-level `test_*` functions in `tests`; for each, materialize a FRESH tempdir (workspace + target + solution.py + tests.py exactly as today) and run the runner with `--only <name>`; if TestCase classes are present, one extra child with `--only __cases__`; aggregate `n_tests` (sum) and failures (`"; "`-joined). Unparseable tests or zero enumerable tests → single legacy child (today's behavior). Child cap 20, surfaced in the report as `"…capped at 20 isolated tests"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/serving/test_serving_accept_gate.py`:
+
+```python
+LEAKY_STATE_CODE = "todos = []\ndef add(item):\n    todos.append(item)\n"
+LEAKY_STATE_TESTS = (
+    "def test_one():\n    add('a')\n    assert len(todos) == 1\n"
+    "def test_two():\n    add('a')\n    add('b')\n    assert len(todos) == 2\n"
+)
+LEAKY_FILE_TESTS = (
+    "import os, json\n"
+    "def save(t):\n    json.dump(t, open('t.json', 'w'))\n"
+    "def test_writes():\n    save([1])\n    assert os.path.exists('t.json')\n"
+    "def test_fresh():\n    assert not os.path.exists('t.json')\n"
+)
+
+
+def test_executor_isolates_module_state_across_tests() -> None:
+    result = _executor("add todos", LEAKY_STATE_CODE, LEAKY_STATE_TESTS)
+    assert result["tests_pass"] is True
+    assert result["n_tests"] == 2
+
+
+def test_executor_isolates_filesystem_across_tests() -> None:
+    result = _executor("save todos", "", LEAKY_FILE_TESTS)
+    assert result["tests_pass"] is True
+    assert result["n_tests"] == 2
+
+
+def test_executor_still_fails_genuinely_wrong_code() -> None:
+    result = _executor(
+        "adds", "def add(a, b):\n    return a - b\n",
+        "def test_add():\n    assert add(1, 2) == 3\n",
+    )
+    assert result["tests_pass"] is False
+    assert "test_add" in result["report"]
+```
+
+(The `LEAKY_FILE_TESTS` fixture defines its helper inside the tests file so the empty-code arm exercises pure test-side isolation.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/serving/test_serving_accept_gate.py -v`
+Expected: the two isolation tests FAIL (leak → `tests_pass` False); the wrong-code test PASSES already (regression guard).
+
+- [ ] **Step 3: Implement**
+
+In `accept_executor.py`, add after the imports:
+
+```python
+import ast
+import re
+
+# per-test isolation (seat-quality design 2026-07-09): each test function
+# runs in its own subprocess with its own fresh materialized directory, so
+# module globals and written files cannot leak across tests. Bounded and
+# surfaced — no silent caps.
+_MAX_ISOLATED_TESTS = 20
+```
+
+Add the enumeration helper:
+
+```python
+def _enumerate_tests(tests: str) -> tuple[list[str], bool] | None:
+    """(top-level test_* function names, has_testcase_classes), or ``None``
+    when the tests don't parse — the caller falls back to one legacy run."""
+    try:
+        tree = ast.parse(tests)
+    except SyntaxError:
+        return None
+    names = [
+        n.name
+        for n in tree.body
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name.startswith("test_")
+    ]
+    has_cases = any(isinstance(n, ast.ClassDef) for n in tree.body)
+    return names, has_cases
+```
+
+Extract the current single-run body into a private helper so both paths share the materialization (structural move, byte-identical behavior):
+
+```python
+def _run_one(
+    code: str,
+    tests: str,
+    workspace: dict[str, str] | None,
+    target_file: str,
+    only: str | None,
+    timeout: float,
+) -> tuple[bool, str, int]:
+    with tempfile.TemporaryDirectory() as tmp:
+        for name, body in (workspace or {}).items():
+            safe = Path(name).name
+            if safe and safe not in ("solution.py", "tests.py"):
+                (Path(tmp) / safe).write_text(str(body), encoding="utf-8")
+        safe_target = Path(target_file).name if target_file else ""
+        if safe_target and safe_target not in ("solution.py", "tests.py"):
+            (Path(tmp) / safe_target).write_text(code, encoding="utf-8")
+        code_path = Path(tmp) / "solution.py"
+        tests_path = Path(tmp) / "tests.py"
+        code_path.write_text(code, encoding="utf-8")
+        tests_path.write_text(tests, encoding="utf-8")
+        argv = [sys.executable, str(RUNNER), str(code_path), str(tests_path)]
+        if only is not None:
+            argv += ["--only", only]
+        try:
+            completed = subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=tmp,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return False, f"timeout after {timeout:g}s", 0
+    if completed.returncode != 0:
+        detail = (completed.stderr.strip() or completed.stdout.strip())[:200]
+        return False, f"runner crashed: {detail}", 0
+    try:
+        verdict = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return False, f"unreadable runner output: {completed.stdout[:200]!r}", 0
+    return (
+        bool(verdict.get("tests_pass", False)),
+        str(verdict.get("report", "")),
+        int(verdict.get("n_tests", 0)),
+    )
+```
+
+Rewrite `_run_sandboxed` to orchestrate per-test children:
+
+```python
+def _run_sandboxed(
+    code: str,
+    tests: str,
+    workspace: dict[str, str] | None = None,
+    target_file: str = "",
+) -> tuple[bool, str, int]:
+    timeout = _timeout()
+    enumerated = _enumerate_tests(tests)
+    if enumerated is None or (not enumerated[0] and not enumerated[1]):
+        # unparseable or nothing enumerable: one legacy run reports it
+        return _run_one(code, tests, workspace, target_file, None, timeout)
+
+    names, has_cases = enumerated
+    capped = len(names) > _MAX_ISOLATED_TESTS
+    children: list[str | None] = list(names[:_MAX_ISOLATED_TESTS])
+    if has_cases:
+        children.append("__cases__")
+
+    failures: list[str] = []
+    total = 0
+    for only in children:
+        ok, report, n_tests = _run_one(
+            code, tests, workspace, target_file, only, timeout
+        )
+        total += n_tests
+        if not ok:
+            failures.append(report)
+    if capped:
+        failures.append(f"…capped at {_MAX_ISOLATED_TESTS} isolated tests")
+
+    # a load failure repeats identically in every child — report it once
+    deduped = list(dict.fromkeys(failures))
+    if deduped:
+        return False, "; ".join(deduped), total
+    return True, "all passed", total
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/serving/ -v`
+Expected: ALL PASS, including the pre-existing executor tests (correct-code pass, wrong-code fail, trivial-tests, timeout — the timeout test's runaway single test now times out in its own child, still reporting failure).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .llm-orc/scripts/agentic_serving/accept_executor.py tests/unit/serving/test_serving_accept_gate.py
+git commit -m "feat: per-test isolation in the accept executor"
+```
+
+---
+
+### Task 4: executor — bare-name-assert sanitizer
+
+**Files:**
+- Modify: `.llm-orc/scripts/agentic_serving/accept_executor.py`
+- Test: `tests/unit/serving/test_serving_accept_gate.py`
+
+**Interfaces:**
+- Consumes: Task 3's executor structure.
+- Produces: `_sanitize_tests(tests: str) -> tuple[str, int]` — drops lines matching a bare-name assert (`assert <identifier>` with optional `, <message>`), returns (sanitized tests, dropped count). `main()` sanitizes before `_run_sandboxed`, echoes the SANITIZED tests in its output (what executed is what ships), and adds `"tests_sanitized": <n>` to the output JSON.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/serving/test_serving_accept_gate.py`:
+
+```python
+STRAY_ASSERT_TESTS = (
+    "def test_overwrite():\n"
+    "    save_todos(['a'])\n"
+    "    assert load\n"
+    "    assert load_todos() == ['a']\n"
+)
+STRAY_CODE = (
+    "_d = {}\n"
+    "def save_todos(t):\n    _d['t'] = t\n"
+    "def load_todos():\n    return _d.get('t', [])\n"
+)
+
+
+def test_bare_name_assert_is_sanitized_before_execution() -> None:
+    result = _executor("storage", STRAY_CODE, STRAY_ASSERT_TESTS)
+    assert result["tests_pass"] is True
+    assert result["tests_sanitized"] == 1
+    assert "assert load\n" not in result["tests"]
+    assert "assert load_todos() == ['a']" in result["tests"]
+
+
+def test_value_bearing_asserts_are_never_sanitized() -> None:
+    tests = "def test_add():\n    assert add(1, 2) == 3\n"
+    result = _executor("adds", "def add(a, b):\n    return a + b\n", tests)
+    assert result["tests_pass"] is True
+    assert result["tests_sanitized"] == 0
+    assert "assert add(1, 2) == 3" in result["tests"]
+
+
+def test_bare_assert_on_an_assigned_local_is_kept() -> None:
+    # 'assert result' on a test-local CAN be a real truthiness check —
+    # only names never assigned in the tests source are value-free.
+    tests = "def test_t():\n    result = add(1, 2)\n    assert result\n"
+    result = _executor("adds", "def add(a, b):\n    return a + b\n", tests)
+    assert result["tests_sanitized"] == 0
+    assert "assert result" in result["tests"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/serving/test_serving_accept_gate.py -v`
+Expected: the sanitizer tests FAIL (`KeyError: 'tests_sanitized'` / NameError reject).
+
+- [ ] **Step 3: Implement**
+
+In `accept_executor.py`, add near `_MAX_ISOLATED_TESTS`:
+
+```python
+# A bare-name assert on a name the tests never assign (``assert load`` /
+# ``assert load, "msg"``) checks only module-object truthiness — a defined
+# function is always truthy, so the line carries no test value, and the
+# 4-arm tier spike (2026-07-09) showed no seat at any tier/thinking mode
+# satisfies a garbage one. Stripped before execution; the echoed (shipped)
+# tests are the sanitized suite. ``assert result`` on an assigned local is
+# a real truthiness check and is kept.
+_BARE_ASSERT_RE = re.compile(r"^\s*assert\s+([A-Za-z_]\w*)\s*(?:,.*)?$")
+_ASSIGNED_NAME_RE = re.compile(r"^\s*([A-Za-z_]\w*)\s*=[^=]", re.MULTILINE)
+
+
+def _sanitize_tests(tests: str) -> tuple[str, int]:
+    """Tests with value-free bare-name assert lines removed, and the count."""
+    assigned = set(_ASSIGNED_NAME_RE.findall(tests))
+    kept: list[str] = []
+    dropped = 0
+    for line in tests.splitlines():
+        match = _BARE_ASSERT_RE.match(line)
+        if match and match.group(1) not in assigned:
+            dropped += 1
+            continue
+        kept.append(line)
+    return "\n".join(kept) + ("\n" if tests.endswith("\n") else ""), dropped
+```
+
+In `main()`, after `tests = str(data.get("tests", ""))`:
+
+```python
+    tests, tests_sanitized = _sanitize_tests(tests)
+```
+
+and add to the printed JSON object:
+
+```python
+                "tests_sanitized": tests_sanitized,
+```
+
+(The existing `"tests": tests` line now echoes the sanitized suite by construction.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/serving/ tests/unit/benchmarks/ -v`
+Expected: ALL PASS (`tests/unit/benchmarks/` guards the judge-adequacy harness, which drives the same executor).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .llm-orc/scripts/agentic_serving/accept_executor.py tests/unit/serving/test_serving_accept_gate.py
+git commit -m "feat: strip value-free bare-name asserts before the accept gate"
+```
+
+---
+
+### Task 5: live validation — regression probes, ladder rerun, docs
+
+Evidence work; expect iteration.
+
+**Files:**
+- Modify: `docs/serving-roadmap.md` (trajectory row; path item 4 status)
+- Modify: `docs/serving.md` if capability wording changes
+
+- [ ] **Step 1: Full suite + lint.** `make test && make lint` — all green before any live run.
+- [ ] **Step 2: Regression probes.** Start `uv run llm-orc serve --port 8765` from the repo root. In a fresh scratch git repo, run the two recorded probes through real OpenCode (`opencode run -m llm-orc/agentic "<prompt>"`, fresh session each):
+  - "write a function that adds a todo item to a list in todo.py" — must ACCEPT (write tool_call) within two attempts.
+  - "create storage.py with save_todos and load_todos functions using json" — must ACCEPT within two attempts.
+- [ ] **Step 3: Ladder rerun.** `LADDER_REPO=<fresh seeded repo> LADDER_OUT=<out dir> benchmarks/agentic_serving/ladder_battery.sh` (seed calc.py per the script header). Score strictly per the trajectory convention; turn 5 must now route to explain; turns 1/4/6 are the ones isolation+sanitizer target.
+- [ ] **Step 4: Docs.** Add the trajectory row with per-class attribution; update path item 4's status in `docs/serving-roadmap.md` (shipped: slices 0/1/2′; deferred: escalation with the 14b-think-off measurement). Commit as `docs: record seat-quality arc ladder results`.
+- [ ] **Step 5: Stop the serve** and report the score with failure classes.
+
+---
+
+## Execution order and dependencies
+
+Tasks 1 → 2 → 3 → 4 → 5. Task 1 is independent but cheapest first; Task 3 requires Task 2's `--only` flag; Task 4 builds on Task 3's executor structure; Task 5 needs everything.
+
+## Out of scope (per spec rev 2)
+
+- Escalation rounds (deferred; if ever built: qwen3:14b think-off via `agentic-tier-escalated-general`).
+- Exception-message assertion sanitizing.
+- Test-writer seat escalation; #83 run half.

--- a/docs/serving-roadmap.md
+++ b/docs/serving-roadmap.md
@@ -31,6 +31,7 @@ model as the backend. Trajectory so far:
 | 2026-07-09 (Stage 2 core) | 9-turn todo app | **8/9** | multi-file build + deep recall pass; one honest reject |
 | 2026-07-09 (#83 read rung) | existing-file battery (3 + 2 regression) | **5/5** | read→gated tests green on a real repo file; honest refusal on a missing file; fresh-build and explain unregressed |
 | 2026-07-09 (v0.18.6) | 10-turn recorded ladder (`benchmarks/agentic_serving/ladder_battery.sh`, new baseline) | **4/10** | #83 rungs all to spec (read→tests 4/4 green mid-session; honest phantom refusal; honest cascade on an unbuilt dependency). Misses: 3 build rejects (round-1 test quality — path item 4's measured class), memory question mis-routed to build (decider flake; "did …?" is not structurally interrogative), deep recall named the latest build not the first (#82 prose-retrieval remainder). Strict scoring; not comparable to earlier unrecorded rows |
+| 2026-07-09 (seat-quality arc) | 10-turn recorded ladder, same seed | **7/10** | Every targeted class converted: memory question routes to explain and answers accurately (decider fix); the storage rung ships (isolation + sanitizer + import injection); its downstream cascade unblocks and the persistence integration is real (todo.py imports storage). Misses: 2 honest build rejects (thinner round-1 test-quality residual) and the known #82 deep-recall deferral. Regression probes: probe 1 accepts attempt 1, probe 2 within two |
 
 The Cycle-7 benchmark harness (`research/agentic-serving-corpus` branch,
 `benchmark-runs/`) is the automation to revive for a standing
@@ -196,10 +197,28 @@ deterministic test sanitizer (path item 4), not more prompt rules.
 
 ### 4. Shapes and seat tiering
 
-Operator-curated catalog growth: fix shape, refactor shape,
-grounded-explain (file-reading explain seat), elicit-then-build
-(criteria-first) as a selectable entry. Escalation-on-signal seat tiering
-(local 14b / hosted) — the default stays local-first per the A/B result.
+**Seat-quality half SHIPPED (2026-07-09, branch
+feat/seat-quality-isolation; design
+`docs/plans/2026-07-09-seat-quality-isolation-escalation-design.md`).**
+Four deterministic gate repairs, no model judgment added: per-test
+isolation in the accept executor (each test function in its own fresh
+sandbox — kills cross-test state/filesystem leakage, the measured
+dominant false-reject class), an aggregate wall budget across isolated
+children (bounded, surfaced), a bare-name-assert sanitizer, deterministic
+missing-import injection into authored tests (os/pytest-style omissions),
+and the classify interrogative fix ("did/have you …" routes to explain).
+Ladder 4/10 → 7/10 on the same seed.
+
+**Escalation deferred with its measurement recorded:** the 4-arm tier
+spike found qwen3:14b think-off generates as fast as 8b think-off on the
+rig (4–13s) while think-on costs 10–20× on either model, and NO arm
+converts what the deterministic repairs don't — every arm plateaued on a
+garbage test line. If a capability-bound class ever survives the repairs,
+the rung is qwen3:14b think-off via `agentic-tier-escalated-general`.
+
+Still open here: operator-curated catalog growth — fix shape, refactor
+shape, grounded-explain (file-reading explain seat), elicit-then-build
+(criteria-first) as a selectable entry.
 
 ### 5. Memory remainder (#82) and beyond-parity
 

--- a/tests/unit/serving/test_serving_accept_executor_runner.py
+++ b/tests/unit/serving/test_serving_accept_executor_runner.py
@@ -1,0 +1,54 @@
+"""Single-test mode for the accept-gate runner (per-test isolation,
+seat-quality design 2026-07-09). Driven via subprocess exactly as
+accept_executor.py invokes it."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[3]
+RUNNER = REPO / ".llm-orc" / "scripts" / "agentic_serving" / "accept_executor_runner.py"
+
+CODE = "todos = []\ndef add(item):\n    todos.append(item)\n"
+LEAKY_TESTS = (
+    "def test_one():\n    add('a')\n    assert len(todos) == 1\n"
+    "def test_two():\n    add('a')\n    add('b')\n    assert len(todos) == 2\n"
+)
+
+
+def _run(code: str, tests: str, tmp: Path, only: str | None = None) -> dict[str, Any]:
+    (tmp / "solution.py").write_text(code)
+    (tmp / "tests.py").write_text(tests)
+    argv = [
+        sys.executable,
+        str(RUNNER),
+        str(tmp / "solution.py"),
+        str(tmp / "tests.py"),
+    ]
+    if only is not None:
+        argv += ["--only", only]
+    out = subprocess.run(argv, capture_output=True, text=True, cwd=tmp, check=True)
+    result: dict[str, Any] = json.loads(out.stdout)
+    return result
+
+
+def test_only_runs_exactly_the_named_test(tmp_path: Path) -> None:
+    verdict = _run(CODE, LEAKY_TESTS, tmp_path, only="test_two")
+    assert verdict["n_tests"] == 1
+    assert verdict["tests_pass"] is True  # fresh namespace: no leaked 'a'
+
+
+def test_only_unknown_name_reports_zero_tests(tmp_path: Path) -> None:
+    verdict = _run(CODE, LEAKY_TESTS, tmp_path, only="test_missing")
+    assert verdict["n_tests"] == 0
+    assert verdict["tests_pass"] is False
+
+
+def test_no_flag_keeps_legacy_whole_run(tmp_path: Path) -> None:
+    verdict = _run(CODE, LEAKY_TESTS, tmp_path)
+    assert verdict["n_tests"] == 2
+    assert verdict["tests_pass"] is False  # the shared-state leak, as today

--- a/tests/unit/serving/test_serving_accept_gate.py
+++ b/tests/unit/serving/test_serving_accept_gate.py
@@ -357,3 +357,52 @@ def test_already_imported_modules_are_not_reinjected() -> None:
     tests = "import os\ndef test_x():\n    assert os.sep\n"
     result = _executor("sep", "", tests)
     assert result["tests_imports_injected"] == 0
+
+
+# --- final-review findings: C1, I1, I2 ---
+
+
+def test_bare_assert_on_a_loop_bound_name_is_kept() -> None:
+    # C1: _ASSIGNED_NAME_RE only matched plain 'name = ...', so a bare
+    # assert on a for-loop-bound name was (wrongly) treated as value-free
+    # and stripped — silently turning a real falsy-value check into a
+    # no-op and letting wrong code through.
+    code = "def all_flags():\n    return [1, 0, 1]\n"
+    tests = (
+        "def test_all_true():\n"
+        "    for flag in all_flags():\n"
+        "        _ = flag\n"
+        "        assert flag\n"
+    )
+    result = _executor("flags", code, tests)
+    assert result["tests_sanitized"] == 0
+    assert result["tests_pass"] is False  # 0 is falsy — the suite must reject
+
+
+def test_nested_test_defs_fall_back_to_legacy_whole_run() -> None:
+    # I1: a test_* def nested under a module-level if/try/for must not be
+    # silently dropped by the per-test isolation path — fall back to one
+    # legacy whole-suite run so completeness matches the pre-isolation
+    # executor.
+    tests = "if True:\n    def test_hidden():\n        assert add(1, 1) == 3\n"
+    result = _executor("adds", "def add(a, b):\n    return a + b\n", tests)
+    assert result["tests_pass"] is False
+    assert "test_hidden" in result["report"]
+
+
+def test_injection_never_shadows_a_code_bound_name() -> None:
+    # I2: an injected 'import os' must not rebind a code-defined 'os' in
+    # the shared runner namespace — that would flip a genuine code bug
+    # (os = None) into a false pass.
+    code = "os = None\n"
+    tests = "def test_os():\n    assert os is not None\n"
+    result = _executor("os check", code, tests)
+    assert result["tests_imports_injected"] == 0
+    assert result["tests_pass"] is False
+
+
+def test_unparseable_tests_skip_injection_and_sanitization() -> None:
+    result = _executor("broken", "x = 1\n", "def test_x(:\n")
+    assert result["tests_sanitized"] == 0
+    assert result["tests_imports_injected"] == 0
+    assert result["tests_pass"] is False

--- a/tests/unit/serving/test_serving_accept_gate.py
+++ b/tests/unit/serving/test_serving_accept_gate.py
@@ -328,3 +328,32 @@ def test_bare_assert_on_an_assigned_local_is_kept() -> None:
     result = _executor("adds", "def add(a, b):\n    return a + b\n", tests)
     assert result["tests_sanitized"] == 0
     assert "assert result" in result["tests"]
+
+
+def test_missing_stdlib_and_pytest_imports_are_injected() -> None:
+    tests = (
+        "def test_raises():\n"
+        "    with pytest.raises(ValueError):\n"
+        "        boom()\n"
+        "def test_file():\n"
+        "    open('x.txt', 'w').write('1')\n"
+        "    assert os.path.exists('x.txt')\n"
+    )
+    code = "def boom():\n    raise ValueError('no')\n"
+    result = _executor("boom raises", code, tests)
+    assert result["tests_pass"] is True
+    assert result["tests_imports_injected"] == 2
+    assert result["tests"].startswith("import os\nimport pytest\n")
+
+
+def test_non_whitelisted_unbound_names_are_not_injected() -> None:
+    tests = "def test_x():\n    assert requests.get is not None\n"
+    result = _executor("http", "", tests)
+    assert result["tests_imports_injected"] == 0
+    assert result["tests_pass"] is False
+
+
+def test_already_imported_modules_are_not_reinjected() -> None:
+    tests = "import os\ndef test_x():\n    assert os.sep\n"
+    result = _executor("sep", "", tests)
+    assert result["tests_imports_injected"] == 0

--- a/tests/unit/serving/test_serving_accept_gate.py
+++ b/tests/unit/serving/test_serving_accept_gate.py
@@ -215,3 +215,38 @@ def test_quoted_string_false_from_the_judge_does_not_pass_the_gate() -> None:
     )
     assert verdict["tests_adequate"] is False
     assert verdict["accept"] is False
+
+
+LEAKY_STATE_CODE = "todos = []\ndef add(item):\n    todos.append(item)\n"
+LEAKY_STATE_TESTS = (
+    "def test_one():\n    add('a')\n    assert len(todos) == 1\n"
+    "def test_two():\n    add('a')\n    add('b')\n    assert len(todos) == 2\n"
+)
+LEAKY_FILE_TESTS = (
+    "import os, json\n"
+    "def save(t):\n    json.dump(t, open('t.json', 'w'))\n"
+    "def test_writes():\n    save([1])\n    assert os.path.exists('t.json')\n"
+    "def test_fresh():\n    assert not os.path.exists('t.json')\n"
+)
+
+
+def test_executor_isolates_module_state_across_tests() -> None:
+    result = _executor("add todos", LEAKY_STATE_CODE, LEAKY_STATE_TESTS)
+    assert result["tests_pass"] is True
+    assert result["n_tests"] == 2
+
+
+def test_executor_isolates_filesystem_across_tests() -> None:
+    result = _executor("save todos", "", LEAKY_FILE_TESTS)
+    assert result["tests_pass"] is True
+    assert result["n_tests"] == 2
+
+
+def test_executor_still_fails_genuinely_wrong_code() -> None:
+    result = _executor(
+        "adds",
+        "def add(a, b):\n    return a - b\n",
+        "def test_add():\n    assert add(1, 2) == 3\n",
+    )
+    assert result["tests_pass"] is False
+    assert "test_add" in result["report"]

--- a/tests/unit/serving/test_serving_accept_gate.py
+++ b/tests/unit/serving/test_serving_accept_gate.py
@@ -290,3 +290,41 @@ def test_executor_still_fails_genuinely_wrong_code() -> None:
     )
     assert result["tests_pass"] is False
     assert "test_add" in result["report"]
+
+
+STRAY_ASSERT_TESTS = (
+    "def test_overwrite():\n"
+    "    save_todos(['a'])\n"
+    "    assert load\n"
+    "    assert load_todos() == ['a']\n"
+)
+STRAY_CODE = (
+    "_d = {}\n"
+    "def save_todos(t):\n    _d['t'] = t\n"
+    "def load_todos():\n    return _d.get('t', [])\n"
+)
+
+
+def test_bare_name_assert_is_sanitized_before_execution() -> None:
+    result = _executor("storage", STRAY_CODE, STRAY_ASSERT_TESTS)
+    assert result["tests_pass"] is True
+    assert result["tests_sanitized"] == 1
+    assert "assert load\n" not in result["tests"]
+    assert "assert load_todos() == ['a']" in result["tests"]
+
+
+def test_value_bearing_asserts_are_never_sanitized() -> None:
+    tests = "def test_add():\n    assert add(1, 2) == 3\n"
+    result = _executor("adds", "def add(a, b):\n    return a + b\n", tests)
+    assert result["tests_pass"] is True
+    assert result["tests_sanitized"] == 0
+    assert "assert add(1, 2) == 3" in result["tests"]
+
+
+def test_bare_assert_on_an_assigned_local_is_kept() -> None:
+    # 'assert result' on a test-local CAN be a real truthiness check —
+    # only names never assigned in the tests source are value-free.
+    tests = "def test_t():\n    result = add(1, 2)\n    assert result\n"
+    result = _executor("adds", "def add(a, b):\n    return a + b\n", tests)
+    assert result["tests_sanitized"] == 0
+    assert "assert result" in result["tests"]

--- a/tests/unit/serving/test_serving_accept_gate.py
+++ b/tests/unit/serving/test_serving_accept_gate.py
@@ -14,6 +14,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -30,9 +31,18 @@ REAL_TESTS = (
 TRIVIAL_TESTS = "def test_callable():\n    assert callable(celsius_to_fahrenheit)\n"
 
 
-def _executor(requirement: str, code: str, tests: str) -> dict[str, Any]:
+def _executor(
+    requirement: str,
+    code: str,
+    tests: str,
+    env_overrides: dict[str, str] | None = None,
+) -> dict[str, Any]:
     payload = json.dumps({"requirement": requirement, "code": code, "tests": tests})
-    env = {**os.environ, "LLM_ORC_ACCEPT_EXECUTOR_TIMEOUT": "3"}
+    env = {
+        **os.environ,
+        "LLM_ORC_ACCEPT_EXECUTOR_TIMEOUT": "3",
+        **(env_overrides or {}),
+    }
     out = subprocess.run(
         [sys.executable, str(EXECUTOR)],
         input=payload,
@@ -92,6 +102,36 @@ def test_executor_sandbox_times_out_on_a_runaway_test() -> None:
     r = _executor("loops forever", CORRECT, runaway)
     assert r["tests_pass"] is False
     assert "timeout" in r["report"].lower()
+
+
+def test_aggregate_budget_bounds_a_many_hang_suite() -> None:
+    # Per-test isolation can spawn up to 21 children, each hanging for the
+    # full per-child timeout — an interactive serve cannot absorb that. The
+    # aggregate budget caps total wall time across the suite and reports it.
+    hang_five = "".join(
+        f"def test_hang_{i}():\n    while True:\n        pass\n" for i in range(5)
+    )
+    start = time.monotonic()
+    r = _executor(
+        "loops forever x5",
+        CORRECT,
+        hang_five,
+        env_overrides={
+            "LLM_ORC_ACCEPT_EXECUTOR_TIMEOUT": "1",
+            "LLM_ORC_ACCEPT_EXECUTOR_BUDGET": "2",
+        },
+    )
+    elapsed = time.monotonic() - start
+    assert elapsed < 10
+    assert r["tests_pass"] is False
+    assert "aggregate budget exhausted after 2s" in r["report"]
+    assert "of 5 tests not run" in r["report"]
+
+
+def test_aggregate_budget_does_not_fire_on_a_normal_suite() -> None:
+    r = _executor("c * 9/5 + 32", CORRECT, REAL_TESTS)
+    assert r["tests_pass"] is True
+    assert "aggregate budget" not in r["report"]
 
 
 def test_executor_passes_the_contract_through_for_the_judge() -> None:

--- a/tests/unit/serving/test_serving_classify.py
+++ b/tests/unit/serving/test_serving_classify.py
@@ -255,3 +255,21 @@ def test_normal_decisions_carry_empty_read_fields() -> None:
     decision = _classify({"task": "write a function that adds two numbers"})
     assert decision["needs_files"] == []
     assert decision["read_failed"] == ""
+
+
+def test_did_you_memory_question_routes_to_explainer_deterministically() -> None:
+    decision = _classify({"task": "did you see my previous query?"})
+    assert decision["target"] == "explainer"
+    assert decision["build"] is False
+    assert decision["needs_decider"] is False
+
+
+def test_have_you_question_routes_to_explainer() -> None:
+    decision = _classify({"task": "have you written any tests yet?"})
+    assert decision["target"] == "explainer"
+
+
+def test_can_you_write_stays_a_build_turn() -> None:
+    decision = _classify({"task": "can you write a function that adds in add.py"})
+    assert decision["target"] != "explainer"
+    assert decision["build"] is True


### PR DESCRIPTION
## What

Four deterministic repairs to the accept gate's measured false-reject classes, plus the classify interrogative fix. No model judgment added anywhere. Recorded 10-turn ladder: **4/10 → 7/10** on the same seed.

Design: `docs/plans/2026-07-09-seat-quality-isolation-escalation-design.md` · Plan: `docs/plans/2026-07-09-seat-quality-plan.md`

## The repairs

- **Per-test isolation**: the accept executor AST-enumerates test functions and runs each in its own subprocess with its own fresh sandbox (runner `--only` mode) — kills cross-test module-state and filesystem leakage, the dominant measured false-reject class. Child cap (20) and an aggregate wall budget (default 3× per-child timeout, env-overridable) are both surfaced in the report, never silent. Nested test defs fall back to the legacy whole run (completeness preserved).
- **Bare-name-assert sanitizer**: strips value-free `assert <name>` lines when the name is bound nowhere in the tests (AST-grounded — for/with/walrus/param bindings all count, so load-bearing truthiness checks survive). The 4-arm tier spike showed no seat at any tier/thinking mode satisfies a garbage assert line.
- **Missing-import injection**: whitelisted stdlib+pytest imports the test-writer omitted get prepended (excluding names the code binds, so injection can never shadow or mask a defect). The echoed artifact ships sanitized+injected — what executed is what ships.
- **classify**: "did/have you …" memory questions route to explain deterministically (the ladder turn-5 mis-route).

## Escalation: measured and deferred

4-arm spike ({8b,14b} × {think on,off}, n=3): every arm identical on the failing fixture; 14b think-off generates as fast as 8b think-off (4–13s), think-on costs 10–20×. No capability-bound class survives the deterministic repairs today. If one appears, the rung is qwen3:14b think-off via the existing `agentic-tier-escalated-general` profile.

## Evidence

- Regression probes (real OpenCode): probe 1 accepts attempt 1 (was: never), probe 2 within two attempts (was: never — its diagnosis produced the import-injection slice).
- Ladder 7/10: memory question answers accurately, the storage rung ships, its downstream cascade unblocks with real cross-file integration. Remaining misses: 2 honest test-quality rejects, the known #82 deep-recall deferral.
- Final Opus review found one Critical (sanitizer wrong-accept on loop-bound names) + two Importants — all fixed and independently re-verified (the wrong-accept repro now rejects; mixed nested-test suites fall back; shadowing guarded).
- Full suite 2674 passed, coverage 91.77%, lint clean.