### PR TITLE
Deterministic gate repairs round 2: the test-quality residual, from live replay evidence

### DIFF
--- a/.llm-orc/ensembles/agentic-serving/build-code-round.yaml
+++ b/.llm-orc/ensembles/agentic-serving/build-code-round.yaml
@@ -17,6 +17,11 @@ description: |
 agents:
   - name: code_writer
     ensemble: code-generator
+    # the held-round input is the system's longest prompt (turn + reject
+    # report + held tests); the 300s default timed out the 3-call
+    # code-generator, shipped empty code, and killed the one convertible
+    # retry (spike 2026-07-10) — bounded by the dispatch/loop budget above
+    timeout_seconds: 600
 
   - name: gather
     script: scripts/agentic_serving/accept_gather.py

--- a/.llm-orc/scripts/agentic_serving/accept_executor.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor.py
@@ -270,6 +270,116 @@ def _guard_unconditional_removals(tests: str) -> tuple[str, int]:
     return "\n".join(lines) + ("\n" if tests.endswith("\n") else ""), len(targets)
 
 
+def _is_assert_false(stmt: ast.stmt) -> bool:
+    return (
+        isinstance(stmt, ast.Assert)
+        and isinstance(stmt.test, ast.Constant)
+        and stmt.test.value is False
+    )
+
+
+def _is_vacuous_else(orelse: list[ast.stmt]) -> bool:
+    """Absent, or a single constant-bool assert (``assert False, msg`` /
+    ``assert True, msg``) — an else that can never check a value."""
+    if not orelse:
+        return True
+    if len(orelse) != 1:
+        return False
+    stmt = orelse[0]
+    return (
+        isinstance(stmt, ast.Assert)
+        and isinstance(stmt.test, ast.Constant)
+        and isinstance(stmt.test.value, bool)
+    )
+
+
+def _declared_expected_exception(handler: ast.excepthandler) -> str:
+    """The exception name a handler both catches and declares expected —
+    ``except <E>: assert False, "...expected...<E>..."`` — else ''."""
+    if not isinstance(handler, ast.ExceptHandler):
+        return ""
+    if len(handler.body) != 1 or not _is_assert_false(handler.body[0]):
+        return ""
+    stmt = handler.body[0]
+    msg = stmt.msg if isinstance(stmt, ast.Assert) else None
+    if not (isinstance(msg, ast.Constant) and isinstance(msg.value, str)):
+        return ""
+    exc = handler.type
+    if not isinstance(exc, ast.Name):
+        return ""
+    if "expected" in msg.value.lower() and exc.id in msg.value:
+        return exc.id
+    return ""
+
+
+def _inverted_expectation(stmt: ast.stmt) -> tuple[ast.Call, str] | None:
+    """(call, exception name) when a statement matches the inverted
+    exception-expectation signature exactly; ``None`` otherwise.
+
+    The exact AST signature (spike 2026-07-10, turn6_s2 r1+r2 and
+    turn1_s5 r2): a try whose body is a single bare call; EVERY handler
+    body is a single ``assert False``; the first handler catches a named
+    exception and its message declares that raise expected ("Expected
+    TypeError"); the else is absent or a vacuous constant-bool assert.
+    Such a test punishes exactly the raise its own message expects — the
+    assert-False belongs after the call / in else. Anything outside the
+    signature (a real else assert, an assert inside the try body, a
+    message that doesn't declare the expectation) is ambiguous and stays
+    untouched, so a correct must-not-raise guard is never inverted.
+    """
+    if not isinstance(stmt, ast.Try) or stmt.finalbody or not stmt.handlers:
+        return None
+    if len(stmt.body) != 1:
+        return None
+    call_stmt = stmt.body[0]
+    if not (isinstance(call_stmt, ast.Expr) and isinstance(call_stmt.value, ast.Call)):
+        return None
+    if not all(
+        len(h.body) == 1 and _is_assert_false(h.body[0]) for h in stmt.handlers
+    ):
+        return None
+    exc_name = _declared_expected_exception(stmt.handlers[0])
+    if not exc_name or not _is_vacuous_else(stmt.orelse):
+        return None
+    return call_stmt.value, exc_name
+
+
+def _rewrite_inverted_expectations(tests: str) -> tuple[str, int]:
+    """Tests with inverted exception-expectations rewritten to the
+    canonical ``with pytest.raises(<E>): <call>`` form, and the count.
+    The pytest import arrives via the existing injection mechanism; the
+    echoed (shipped) tests carry the rewrite (v0.18.7 convention)."""
+    try:
+        tree = ast.parse(tests)
+    except SyntaxError:
+        return tests, 0
+    found: list[tuple[ast.Try, ast.Call, str]] = []
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not node.name.startswith("test_"):
+            continue
+        for stmt in node.body:
+            match = _inverted_expectation(stmt)
+            if match is not None and isinstance(stmt, ast.Try):
+                found.append((stmt, match[0], match[1]))
+    if not found:
+        return tests, 0
+    lines = tests.splitlines()
+    for try_stmt, call, exc_name in sorted(
+        found, key=lambda item: item[0].lineno, reverse=True
+    ):
+        start = try_stmt.lineno - 1
+        end = try_stmt.end_lineno or try_stmt.lineno
+        indent = " " * try_stmt.col_offset
+        call_src = ast.get_source_segment(tests, call) or ast.unparse(call)
+        lines[start:end] = [
+            f"{indent}with pytest.raises({exc_name}):",
+            f"{indent}    {call_src}",
+        ]
+    return "\n".join(lines) + ("\n" if tests.endswith("\n") else ""), len(found)
+
+
 def _from_dependencies(envelope: dict[str, object]) -> dict[str, object] | None:
     """The ``{requirement, code, tests}`` contract from a dependency (the
     build-gated ``gather`` node), when the executor runs inside the ensemble.
@@ -515,6 +625,7 @@ def main() -> None:
     tests, tests_sanitized = _sanitize_tests(tests)
     tests, tests_excised = _excise_unbound_callable_tests(tests, code)
     tests, tests_removals_guarded = _guard_unconditional_removals(tests)
+    tests, tests_raises_rewritten = _rewrite_inverted_expectations(tests)
     tests, tests_imports_injected = _inject_test_imports(tests, code)
     raw_workspace = data.get("workspace")
     workspace = (
@@ -538,6 +649,7 @@ def main() -> None:
                 "tests_sanitized": tests_sanitized,
                 "tests_excised": tests_excised,
                 "tests_removals_guarded": tests_removals_guarded,
+                "tests_raises_rewritten": tests_raises_rewritten,
                 "tests_imports_injected": tests_imports_injected,
                 "report": report,
             }

--- a/.llm-orc/scripts/agentic_serving/accept_executor.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor.py
@@ -121,8 +121,12 @@ def _param_names(args: ast.arguments) -> set[str]:
 
 def _bound_names(tree: ast.Module) -> set[str]:
     """Every name the tests source binds: assignments, for/with targets (all
-    ``ast.Name`` in Store context), def/class names, function parameters, and
-    import aliases — the rest are candidates for import injection."""
+    ``ast.Name`` in Store context), def/class names, function AND lambda
+    parameters, except-handler aliases, and import aliases — the rest are
+    candidates for import injection. Lambda params and handler aliases were
+    missed pre-review (probe P3b, 2026-07-10): harmless for injection (it
+    only errs toward injecting) but excision turned the gap into silently
+    dropping a good test."""
     bound = {
         n.id
         for n in ast.walk(tree)
@@ -131,8 +135,10 @@ def _bound_names(tree: ast.Module) -> set[str]:
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
             bound.add(node.name)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
             bound |= _param_names(node.args)
+        if isinstance(node, ast.ExceptHandler) and node.name:
+            bound.add(node.name)
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             bound |= {a.asname or a.name.split(".")[0] for a in node.names}
     return bound
@@ -231,15 +237,39 @@ def _is_bare_os_removal(stmt: ast.stmt) -> bool:
     )
 
 
-def _guard_unconditional_removals(tests: str) -> tuple[str, int]:
-    """Tests with bare top-of-test-body removals suppressed, and the count.
+def _setup_removals(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, code_bound: set[str]
+) -> list[ast.stmt]:
+    """Bare removals in the SETUP region only — before the first statement
+    that references a code-bound name. A removal AFTER the code ran is an
+    implicit the-file-was-created assertion; wrapping it would neuter the
+    check and accept code that never writes (review probe P2b,
+    2026-07-10)."""
+    removals: list[ast.stmt] = []
+    for stmt in node.body:
+        if _is_bare_os_removal(stmt):
+            removals.append(stmt)
+            continue
+        loads = {
+            n.id
+            for n in ast.walk(stmt)
+            if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)
+        }
+        if loads & code_bound:
+            break
+    return removals
+
+
+def _guard_unconditional_removals(tests: str, code: str) -> tuple[str, int]:
+    """Tests with bare SETUP-position removals suppressed, and the count.
 
     Spike 2026-07-10 (turn6_s4 r1+r2): setup deletes a file that never
     exists in the fresh per-test sandbox — per-test isolation itself
     created this failure mode — and the FileNotFoundError fires before any
     assert. A bare ``os.remove(...)`` / ``os.unlink(...)`` expression
-    statement directly in a test function's body (so never one already
-    inside try/with) is wrapped in ``with contextlib.suppress(
+    statement in a test function's setup region (before any code-bound
+    name is referenced, so never one already inside try/with and never a
+    post-call existence check) is wrapped in ``with contextlib.suppress(
     FileNotFoundError):``; the contextlib import arrives via the existing
     injection mechanism. Same shape as import injection: the artifact
     becomes self-consistent without touching what it asserts about the
@@ -249,13 +279,16 @@ def _guard_unconditional_removals(tests: str) -> tuple[str, int]:
         tree = ast.parse(tests)
     except SyntaxError:
         return tests, 0
+    try:
+        code_bound = _bound_names(ast.parse(code)) - _BUILTIN_NAMES
+    except SyntaxError:
+        code_bound = set()
     targets = [
         stmt
         for node in tree.body
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
         and node.name.startswith("test_")
-        for stmt in node.body
-        if _is_bare_os_removal(stmt)
+        for stmt in _setup_removals(node, code_bound)
     ]
     if not targets:
         return tests, 0
@@ -306,6 +339,22 @@ def _exception_source(exc: ast.expr | None) -> tuple[str, str]:
     return "", ""
 
 
+def _declares_expectation(msg: str, declared: str) -> bool:
+    """A positive, whole-word declaration that the named exception is
+    expected. Substring matching was a wrong-accept vector (review probes
+    2026-07-10): "Unexpected ValueError" contains "expected" and would
+    invert a correct must-not-raise guard; "Error" is a substring of
+    "KeyError" and matched the wrong class. Whole-word ``expected`` never
+    matches inside "unexpected"; a negation token anywhere refuses; the
+    exception name must appear as a whole word."""
+    lowered = msg.lower()
+    if not re.search(r"\bexpected\b", lowered):
+        return False
+    if re.search(r"\b(?:not|never|no)\b", lowered):
+        return False
+    return bool(re.search(rf"\b{re.escape(declared)}\b", msg))
+
+
 def _declared_expected_exception(handler: ast.excepthandler) -> str:
     """The exception source a handler both catches and declares expected —
     ``except <E>: assert False, "...expected...<E>..."`` — else ''."""
@@ -318,7 +367,7 @@ def _declared_expected_exception(handler: ast.excepthandler) -> str:
     if not (isinstance(msg, ast.Constant) and isinstance(msg.value, str)):
         return ""
     source, declared = _exception_source(handler.type)
-    if source and "expected" in msg.value.lower() and declared in msg.value:
+    if source and _declares_expectation(msg.value, declared):
         return source
     return ""
 
@@ -635,7 +684,7 @@ def main() -> None:
     tests = str(data.get("tests", ""))
     tests, tests_sanitized = _sanitize_tests(tests)
     tests, tests_excised = _excise_unbound_callable_tests(tests, code)
-    tests, tests_removals_guarded = _guard_unconditional_removals(tests)
+    tests, tests_removals_guarded = _guard_unconditional_removals(tests, code)
     tests, tests_raises_rewritten = _rewrite_inverted_expectations(tests)
     tests, tests_imports_injected = _inject_test_imports(tests, code)
     raw_workspace = data.get("workspace")

--- a/.llm-orc/scripts/agentic_serving/accept_executor.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor.py
@@ -89,6 +89,7 @@ def _sanitize_tests(tests: str) -> tuple[str, int]:
 _INJECTABLE_MODULES = frozenset(
     {
         "collections",
+        "contextlib",
         "functools",
         "itertools",
         "json",
@@ -215,6 +216,58 @@ def _excise_unbound_callable_tests(tests: str, code: str) -> tuple[str, int]:
         start = min([func.lineno, *(d.lineno for d in func.decorator_list)]) - 1
         del lines[start : (func.end_lineno or func.lineno)]
     return "\n".join(lines) + ("\n" if tests.endswith("\n") else ""), len(doomed)
+
+
+def _is_bare_os_removal(stmt: ast.stmt) -> bool:
+    """A bare ``os.remove(...)`` / ``os.unlink(...)`` expression statement."""
+    if not (isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call)):
+        return False
+    func = stmt.value.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr in ("remove", "unlink")
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "os"
+    )
+
+
+def _guard_unconditional_removals(tests: str) -> tuple[str, int]:
+    """Tests with bare top-of-test-body removals suppressed, and the count.
+
+    Spike 2026-07-10 (turn6_s4 r1+r2): setup deletes a file that never
+    exists in the fresh per-test sandbox — per-test isolation itself
+    created this failure mode — and the FileNotFoundError fires before any
+    assert. A bare ``os.remove(...)`` / ``os.unlink(...)`` expression
+    statement directly in a test function's body (so never one already
+    inside try/with) is wrapped in ``with contextlib.suppress(
+    FileNotFoundError):``; the contextlib import arrives via the existing
+    injection mechanism. Same shape as import injection: the artifact
+    becomes self-consistent without touching what it asserts about the
+    code. The echoed (shipped) tests carry the wrap.
+    """
+    try:
+        tree = ast.parse(tests)
+    except SyntaxError:
+        return tests, 0
+    targets = [
+        stmt
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+        for stmt in node.body
+        if _is_bare_os_removal(stmt)
+    ]
+    if not targets:
+        return tests, 0
+    lines = tests.splitlines()
+    for stmt in sorted(targets, key=lambda s: s.lineno, reverse=True):
+        start, end = stmt.lineno - 1, stmt.end_lineno or stmt.lineno
+        indent = " " * stmt.col_offset
+        block = [f"{indent}with contextlib.suppress(FileNotFoundError):"] + [
+            f"    {line}" for line in lines[start:end]
+        ]
+        lines[start:end] = block
+    return "\n".join(lines) + ("\n" if tests.endswith("\n") else ""), len(targets)
 
 
 def _from_dependencies(envelope: dict[str, object]) -> dict[str, object] | None:
@@ -461,6 +514,7 @@ def main() -> None:
     tests = str(data.get("tests", ""))
     tests, tests_sanitized = _sanitize_tests(tests)
     tests, tests_excised = _excise_unbound_callable_tests(tests, code)
+    tests, tests_removals_guarded = _guard_unconditional_removals(tests)
     tests, tests_imports_injected = _inject_test_imports(tests, code)
     raw_workspace = data.get("workspace")
     workspace = (
@@ -483,6 +537,7 @@ def main() -> None:
                 "n_tests": n_tests,
                 "tests_sanitized": tests_sanitized,
                 "tests_excised": tests_excised,
+                "tests_removals_guarded": tests_removals_guarded,
                 "tests_imports_injected": tests_imports_injected,
                 "report": report,
             }

--- a/.llm-orc/scripts/agentic_serving/accept_executor.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor.py
@@ -166,6 +166,57 @@ def _inject_test_imports(tests: str, code: str) -> tuple[str, int]:
     return f"{prelude}\n\n{tests}", len(missing)
 
 
+def _calls_unbound_name(func: ast.AST, bound: set[str]) -> bool:
+    """Whether a test function calls a bare name outside ``bound`` — a
+    guaranteed NameError no code regeneration can convert."""
+    return any(
+        isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id not in bound
+        for n in ast.walk(func)
+    )
+
+
+def _excise_unbound_callable_tests(tests: str, code: str) -> tuple[str, int]:
+    """Tests minus the ones calling a name bound nowhere, and the count.
+
+    Spike 2026-07-10 (turn6_s2/turn6_s5): ``assert file_exists(...)`` — a
+    call to a bare name the tests never bind, the code deliverable never
+    defines, and neither builtins nor the injectable-module whitelist can
+    supply. The line NameErrors in every round; excising that one test and
+    running the remainder is honest, where name-mapping (``file_exists ->
+    os.path.exists``) would risk changing intent. Scope: top-level
+    ``test_*`` functions (per-test isolation's unit). Bounded: if excision
+    would drop ALL test units, the suite is returned unchanged so the
+    round rejects on the real NameError. The echoed (shipped) tests are
+    the excised suite, per the v0.18.7 repair convention.
+    """
+    try:
+        tree = ast.parse(tests)
+    except SyntaxError:
+        return tests, 0
+    try:
+        code_bound = _bound_names(ast.parse(code))
+    except SyntaxError:
+        code_bound = set()
+    bound = _bound_names(tree) | code_bound | _BUILTIN_NAMES | _INJECTABLE_MODULES
+    test_funcs = [
+        n
+        for n in tree.body
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name.startswith("test_")
+    ]
+    doomed = [f for f in test_funcs if _calls_unbound_name(f, bound)]
+    has_cases = any(isinstance(n, ast.ClassDef) for n in tree.body)
+    if not doomed or (len(doomed) == len(test_funcs) and not has_cases):
+        return tests, 0
+    lines = tests.splitlines()
+    for func in sorted(doomed, key=lambda f: f.lineno, reverse=True):
+        start = min([func.lineno, *(d.lineno for d in func.decorator_list)]) - 1
+        del lines[start : (func.end_lineno or func.lineno)]
+    return "\n".join(lines) + ("\n" if tests.endswith("\n") else ""), len(doomed)
+
+
 def _from_dependencies(envelope: dict[str, object]) -> dict[str, object] | None:
     """The ``{requirement, code, tests}`` contract from a dependency (the
     build-gated ``gather`` node), when the executor runs inside the ensemble.
@@ -409,6 +460,7 @@ def main() -> None:
     code = str(data.get("code", ""))
     tests = str(data.get("tests", ""))
     tests, tests_sanitized = _sanitize_tests(tests)
+    tests, tests_excised = _excise_unbound_callable_tests(tests, code)
     tests, tests_imports_injected = _inject_test_imports(tests, code)
     raw_workspace = data.get("workspace")
     workspace = (
@@ -430,6 +482,7 @@ def main() -> None:
                 "tests_pass": tests_pass,
                 "n_tests": n_tests,
                 "tests_sanitized": tests_sanitized,
+                "tests_excised": tests_excised,
                 "tests_imports_injected": tests_imports_injected,
                 "report": report,
             }

--- a/.llm-orc/scripts/agentic_serving/accept_executor.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor.py
@@ -293,8 +293,21 @@ def _is_vacuous_else(orelse: list[ast.stmt]) -> bool:
     )
 
 
+def _exception_source(exc: ast.expr | None) -> tuple[str, str]:
+    """(source form, declared name) for a bare or dotted exception type —
+    ``ValueError`` -> ("ValueError", "ValueError"); the Attribute form
+    ``json.JSONDecodeError`` (validation replays 2026-07-10: the natural
+    spelling for the storage turn, rejected in every sample) ->
+    ("json.JSONDecodeError", "JSONDecodeError"). ("", "") otherwise."""
+    if isinstance(exc, ast.Name):
+        return exc.id, exc.id
+    if isinstance(exc, ast.Attribute) and isinstance(exc.value, ast.Name):
+        return f"{exc.value.id}.{exc.attr}", exc.attr
+    return "", ""
+
+
 def _declared_expected_exception(handler: ast.excepthandler) -> str:
-    """The exception name a handler both catches and declares expected —
+    """The exception source a handler both catches and declares expected —
     ``except <E>: assert False, "...expected...<E>..."`` — else ''."""
     if not isinstance(handler, ast.ExceptHandler):
         return ""
@@ -304,11 +317,9 @@ def _declared_expected_exception(handler: ast.excepthandler) -> str:
     msg = stmt.msg if isinstance(stmt, ast.Assert) else None
     if not (isinstance(msg, ast.Constant) and isinstance(msg.value, str)):
         return ""
-    exc = handler.type
-    if not isinstance(exc, ast.Name):
-        return ""
-    if "expected" in msg.value.lower() and exc.id in msg.value:
-        return exc.id
+    source, declared = _exception_source(handler.type)
+    if source and "expected" in msg.value.lower() and declared in msg.value:
+        return source
     return ""
 
 

--- a/.llm-orc/scripts/agentic_serving/accept_executor_runner.py
+++ b/.llm-orc/scripts/agentic_serving/accept_executor_runner.py
@@ -66,7 +66,13 @@ def _run_test_fns(test_fns: list, tests: str) -> tuple[int, list[str]]:
                 # an async test returns a coroutine that raised nothing yet —
                 # uncollected it would count as a silent pass (wrong accept)
                 asyncio.run(result)
-        except Exception as error:  # noqa: BLE001
+        except (KeyboardInterrupt, SystemExit, GeneratorExit):
+            raise
+        except BaseException as error:  # noqa: BLE001
+            # BaseException, not Exception: pytest's Failed (the
+            # pytest.raises DID-NOT-RAISE outcome) derives from
+            # BaseException and must report as a clean per-test failure,
+            # not crash the runner child (validation replay 2026-07-10)
             line = _failing_line(error, tests)
             detail = f"{name}: {error!r}"
             if line:

--- a/.llm-orc/scripts/agentic_serving/accept_gate.py
+++ b/.llm-orc/scripts/agentic_serving/accept_gate.py
@@ -55,41 +55,50 @@ def _extract_bool(resp: str, key: str) -> bool | None:
     return None
 
 
-def main() -> None:
-    raw = sys.stdin.read().strip()
-    deps: dict[str, object] = {}
+def _read_deps(raw: str) -> dict[str, object]:
     try:
         envelope = json.loads(raw)
-        if isinstance(envelope, dict):
-            found = envelope.get("dependencies", {})
-            deps = found if isinstance(found, dict) else {}
     except (json.JSONDecodeError, TypeError):
-        deps = {}
+        return {}
+    if isinstance(envelope, dict):
+        found = envelope.get("dependencies", {})
+        return found if isinstance(found, dict) else {}
+    return {}
 
-    tests_pass = _extract_bool(_dep_response(deps, "executor"), "tests_pass")
-    # the judge is a sub-ensemble seat (#84): its dep response is the nested
-    # child-result envelope — peel to the model's raw verdict (terminal() is
-    # a no-op on a bare verdict, so both shapes read)
+
+def _resolve_adequacy(
+    deps: dict[str, object], reasons: list[str]
+) -> tuple[bool, bool]:
+    """(tests_adequate, carried) from the judge verdict or the held flag.
+
+    The judge is a sub-ensemble seat (#84): its dep response is the nested
+    child-result envelope — peel to the model's raw verdict (terminal() is
+    a no-op on a bare verdict, so both shapes read). Held round (issue
+    #100): no judge seat — the held path only fires when round 1's judge
+    passed these exact tests, so the verdict carries deterministically;
+    the executor stays the live gate. No judge AND no held flag is a
+    miswired shape, not a free pass.
+    """
     tests_adequate = _extract_bool(
         _terminal(_dep_response(deps, "judge")), "tests_adequate"
     )
+    if tests_adequate is not None:
+        return tests_adequate, False
+    if _extract_bool(_dep_response(deps, "gather"), "held"):
+        return True, True
+    reasons.append("judge verdict unreadable")
+    return False, False
 
+
+def main() -> None:
+    deps = _read_deps(sys.stdin.read().strip())
+
+    tests_pass = _extract_bool(_dep_response(deps, "executor"), "tests_pass")
     reasons: list[str] = []
-    carried = False
     if tests_pass is None:
         tests_pass = False
         reasons.append("executor verdict unreadable")
-    if tests_adequate is None:
-        # held round (issue #100): no judge seat — the held path only fires
-        # when round 1's judge passed these exact tests, so the verdict
-        # carries deterministically; the executor stays the live gate.
-        # No judge AND no held flag is a miswired shape, not a free pass.
-        if _extract_bool(_dep_response(deps, "gather"), "held"):
-            tests_adequate = True
-            carried = True
-        else:
-            tests_adequate = False
-            reasons.append("judge verdict unreadable")
+    tests_adequate, carried = _resolve_adequacy(deps, reasons)
 
     accept = bool(tests_pass and tests_adequate)
     if not accept and not reasons:

--- a/.llm-orc/scripts/agentic_serving/accept_gather.py
+++ b/.llm-orc/scripts/agentic_serving/accept_gather.py
@@ -24,14 +24,6 @@ from _helpers import response as _response
 from _helpers import terminal as _terminal
 
 
-
-
-
-
-
-
-
-
 def _trim_to_parse(code: str, max_drops: int = 10) -> str:
     """Drop trailing non-parsing lines (bounded) — seat models sometimes leave
     a prose usage line inside the fence. Valid code returns byte-identical;

--- a/.llm-orc/scripts/agentic_serving/adequacy_check.py
+++ b/.llm-orc/scripts/agentic_serving/adequacy_check.py
@@ -14,8 +14,13 @@ Value-bearing forms: a comparison containing a real call whose two sides
 are not the same expression (directly or via a variable assigned from the
 same call — the tautology channel); a truthy assert that IS a real call
 (``assert is_even(4)``); unittest assert methods over a real call; an
-exception-expectation try/except around a real call. Reflection calls
-(callable/hasattr/isinstance/type/...) are never value-bearing.
+exception-expectation try/except around a real call; a mutation-pattern
+compare — a name (or subscript of it) checked against an independent
+literal/container after that name was passed as an argument to a real
+call earlier in the same test body (the spike's turn1_s5 false-reject
+class, 2026-07-10: ``add_todo(todos, "x"); assert todos == ["x"]``).
+Reflection calls (callable/hasattr/isinstance/type/...) are never
+value-bearing.
 
 Emits the judge seat's contract: {"tests_adequate": bool, "reason": str} —
 the accept gate reads it unchanged. Deterministic control per the standing
@@ -27,6 +32,7 @@ from __future__ import annotations
 import ast
 import json
 import sys
+from collections.abc import Iterator
 from typing import Any
 
 from _helpers import deps as _deps
@@ -139,6 +145,89 @@ def _expect_raise_with(node: ast.With | ast.AsyncWith) -> bool:
     return False
 
 
+def _literal_like(node: ast.AST) -> bool:
+    """A literal or a container of literals — an independent expected value
+    the code cannot have produced."""
+    if isinstance(node, ast.Constant):
+        return True
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return all(_literal_like(e) for e in node.elts)
+    if isinstance(node, ast.Dict):
+        keys_ok = all(k is not None and _literal_like(k) for k in node.keys)
+        return keys_ok and all(_literal_like(v) for v in node.values)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        return _literal_like(node.operand)
+    return False
+
+
+def _base_name(node: ast.expr) -> str:
+    """The underlying name of a Name or a (nested) subscript of one."""
+    while isinstance(node, ast.Subscript):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else ""
+
+
+def _call_arg_names(stmt: ast.stmt) -> set[str]:
+    """Bare names passed as arguments to real calls in one statement —
+    candidates a ``None``-returning mutator may have mutated."""
+    names: set[str] = set()
+    for call in _real_calls(stmt):
+        for arg in (*call.args, *(kw.value for kw in call.keywords)):
+            if isinstance(arg, ast.Name):
+                names.add(arg.id)
+    return names
+
+
+def _mutation_compare(node: ast.Compare, mutated: set[str]) -> bool:
+    """A call-free compare of a mutated name (or subscript of it) against
+    an independent literal/container — the mutation-test pattern."""
+    if _real_calls(node) or len(node.comparators) != 1:
+        return False
+    left, right = node.left, node.comparators[0]
+    return any(
+        _base_name(side) in mutated and _literal_like(other)
+        for side, other in ((left, right), (right, left))
+    )
+
+
+def _ordered_statements(body: list[ast.stmt]) -> Iterator[ast.stmt]:
+    """Statements in source order, recursing into compound bodies."""
+    for stmt in body:
+        yield stmt
+        for handler in getattr(stmt, "handlers", []):
+            yield from _ordered_statements(handler.body)
+        for field in ("body", "orelse", "finalbody"):
+            nested = getattr(stmt, field, None)
+            if nested:
+                yield from _ordered_statements(nested)
+
+
+def _mutation_asserts(unit: ast.AST) -> int:
+    """Mutation-pattern asserts in a test unit: the compared name was passed
+    to a real call EARLIER in the same test body, then checked against a
+    literal/container (spike 2026-07-10, turn1_s5 false-reject class —
+    ``add_todo(todos, "x"); assert todos == ["x"]``). Disjoint from
+    ``_value_bearing_asserts``'s compare rule, which requires a real call
+    inside the compare; this rule requires the compare be call-free."""
+    count = 0
+    funcs = [
+        n
+        for n in ast.walk(unit)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    for func in funcs:
+        mutated: set[str] = set()
+        for stmt in _ordered_statements(func.body):
+            if (
+                isinstance(stmt, ast.Assert)
+                and isinstance(stmt.test, ast.Compare)
+                and _mutation_compare(stmt.test, mutated)
+            ):
+                count += 1
+            mutated |= _call_arg_names(stmt)
+    return count
+
+
 def _value_bearing_asserts(unit: ast.AST) -> int:
     """Value-bearing asserts within one test unit (function or class)."""
     assigned = _assigned_call_signatures(unit)
@@ -167,7 +256,7 @@ def _value_bearing_asserts(unit: ast.AST) -> int:
                 and _has_failure_signal(node.body)
             ):
                 count += 1
-    return count
+    return count + _mutation_asserts(unit)
 
 
 def _is_test_class(node: ast.ClassDef) -> bool:

--- a/.llm-orc/scripts/agentic_serving/adequacy_check.py
+++ b/.llm-orc/scripts/agentic_serving/adequacy_check.py
@@ -228,34 +228,42 @@ def _mutation_asserts(unit: ast.AST) -> int:
     return count
 
 
+def _assert_is_value_bearing(node: ast.Assert, assigned: dict[str, str]) -> bool:
+    test = node.test
+    if isinstance(test, ast.Compare):
+        return _compare_is_value_bearing(test, assigned)
+    return isinstance(test, ast.Call) and _call_name(test) not in _EXCLUDED_CALLS
+
+
+def _try_is_value_bearing(node: ast.Try) -> bool:
+    specific = any(handler.type is not None for handler in node.handlers)
+    return (
+        specific
+        and any(_real_calls(stmt) for stmt in node.body)
+        and _has_failure_signal(node.body)
+    )
+
+
+def _node_is_value_bearing(node: ast.AST, assigned: dict[str, str]) -> bool:
+    if isinstance(node, ast.Assert):
+        return _assert_is_value_bearing(node, assigned)
+    if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+        return _unittest_assert_is_value_bearing(node.value, assigned)
+    if isinstance(node, (ast.With, ast.AsyncWith)):
+        return _expect_raise_with(node) and any(
+            _real_calls(stmt) for stmt in node.body
+        )
+    if isinstance(node, ast.Try):
+        return _try_is_value_bearing(node)
+    return False
+
+
 def _value_bearing_asserts(unit: ast.AST) -> int:
     """Value-bearing asserts within one test unit (function or class)."""
     assigned = _assigned_call_signatures(unit)
-    count = 0
-    for node in ast.walk(unit):
-        if isinstance(node, ast.Assert):
-            test = node.test
-            if isinstance(test, ast.Compare):
-                if _compare_is_value_bearing(test, assigned):
-                    count += 1
-            elif isinstance(test, ast.Call) and _call_name(test) not in _EXCLUDED_CALLS:
-                count += 1
-        elif isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
-            if _unittest_assert_is_value_bearing(node.value, assigned):
-                count += 1
-        elif isinstance(node, (ast.With, ast.AsyncWith)):
-            if _expect_raise_with(node) and any(
-                _real_calls(stmt) for stmt in node.body
-            ):
-                count += 1
-        elif isinstance(node, ast.Try):
-            specific = any(handler.type is not None for handler in node.handlers)
-            if (
-                specific
-                and any(_real_calls(stmt) for stmt in node.body)
-                and _has_failure_signal(node.body)
-            ):
-                count += 1
+    count = sum(
+        1 for node in ast.walk(unit) if _node_is_value_bearing(node, assigned)
+    )
     return count + _mutation_asserts(unit)
 
 

--- a/.llm-orc/scripts/agentic_serving/build_gated_envelope.py
+++ b/.llm-orc/scripts/agentic_serving/build_gated_envelope.py
@@ -24,10 +24,6 @@ from _helpers import response as _response
 from _helpers import terminal as _terminal
 
 
-
-
-
-
 def _executor_result(deps: dict[str, object]) -> dict[str, object]:
     try:
         parsed = json.loads(_response(deps.get("executor", {})))

--- a/.llm-orc/scripts/agentic_serving/emit_envelope.py
+++ b/.llm-orc/scripts/agentic_serving/emit_envelope.py
@@ -13,13 +13,12 @@ CONTENT; the serving classify owns the DESTINATION path — shape combines them.
 from __future__ import annotations
 
 import json
+import sys
 
 from _helpers import extract_code as _extract_code
 from _helpers import payload as __payload
 from _helpers import response as _response
 from _helpers import terminal as _terminal
-import re
-import sys
 
 
 def _deps(raw: str) -> dict:

--- a/.llm-orc/scripts/agentic_serving/seat_contract.py
+++ b/.llm-orc/scripts/agentic_serving/seat_contract.py
@@ -18,13 +18,12 @@ from __future__ import annotations
 
 import asyncio
 import json
-
-from _helpers import terminal as _terminal
 import sys
 from pathlib import Path
 from typing import Any
 
 import yaml
+from _helpers import terminal as _terminal
 
 from llm_orc.core.validation.models import ValidationConfig
 from llm_orc.core.validation.seat_contract import SEAT_OUTPUT_KEY, admit

--- a/.llm-orc/scripts/agentic_serving/shape.py
+++ b/.llm-orc/scripts/agentic_serving/shape.py
@@ -17,9 +17,9 @@ gracefully rather than requiring every seat to envelope first.
 from __future__ import annotations
 
 import json
+import sys
 
 from _helpers import terminal as _terminal
-import sys
 
 
 def _deps(raw: str) -> dict:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.10] - 2026-07-10
+
+### Added
+- Deterministic gate repairs, round 2 (from 11 live replay captures of
+  the battery's failing build turns — code wrong in 0 of 8 rejected
+  rounds; the tests were): unbound-callable test excision (a test
+  calling a name bound nowhere is removed, bounded so an excised-to-
+  empty suite still rejects); unguarded `os.remove`/`os.unlink` setup
+  wrapped in `contextlib.suppress(FileNotFoundError)`; inverted
+  exception-expectations (`except E: assert False, "expected E"`, bare
+  and dotted forms) rewritten to `with pytest.raises(E):`. All repairs
+  AST-grounded with exact signatures, echoed into the shipped artifact
+  with counts
+
+### Fixed
+- Adequacy check counts mutation-pattern asserts as value-bearing
+  (`add_todo(todos, "x"); assert todos == ["x"]` no longer false-rejects
+  and cascades into a worse resample)
+- The held TDD retry's code_writer ran under the 300s default timeout on
+  the system's longest input, shipping empty code — explicit 600s
+  headroom; the one convertible retry class now converts
+- pytest outcome exceptions (DID-NOT-RAISE) report as clean per-test
+  failures instead of crashing the runner child with a truncated report
+
 ## [0.18.9] - 2026-07-10
 
 ### Fixed

--- a/docs/plans/2026-07-10-test-repair-round-2-design.md
+++ b/docs/plans/2026-07-10-test-repair-round-2-design.md
@@ -95,3 +95,48 @@ TDD per repair with the spike's verbatim exemplars as fixtures; full
 suite; live replay of the two spike turns (expect turn6's never-accept
 rate to drop); recorded ladder rerun + trajectory row; independent
 adversarial review with the wrong-accept class as the named target.
+
+## Validation round (2026-07-10, 7 replays on the repaired branch)
+
+The repairs fired live: turn1_sv1 accepted round 1 WITH an in-flight
+rewrite; turn6_sv5 converted end-to-end (2 excisions + 1 rewrite +
+the fixed timeout → held round accepted a previously-fatal shape). Two
+defects the validation surfaced, both fixed on-branch:
+
+- **Runner crash on DID-NOT-RAISE:** pytest's `Failed` derives from
+  `BaseException`, so a repaired `pytest.raises` test whose expected
+  exception never raised crashed the runner child (fail-closed, but the
+  report was a truncated traceback — no evidence for the retry round).
+  The runner now catches `BaseException` (KeyboardInterrupt/SystemExit/
+  GeneratorExit still propagate).
+- **Attribute-form coverage gap:** every remaining turn6 reject
+  (sv1/sv3/sv4) was `except json.JSONDecodeError:` — the dotted form the
+  Name-only rewrite signature skipped. Widened; the declared-expectation
+  check matches the dotted name's last segment.
+
+Second review round (independent adversarial reviewer, wrong-accept as
+the named target) found and we fixed three wrong-accept vectors before
+merge: substring expectation-matching ("Unexpected ValueError" inverted a
+correct guard; "Error" matched inside "KeyError"), anywhere-in-body
+removal wrapping (neutered post-call existence assertions), and
+lambda-param/except-alias blindness in the binding scan (excised a good
+test). Post-fix seams, both fail-closed and accepted: negation tokens
+anywhere in a message refuse the rewrite ("Expected TypeError not
+raised" now costs a round instead of converting — tighten to
+expectation-adjacent negation if ladder evidence demands), and a setup
+removal after an `os.`-using fixture statement goes unwrapped when the
+code also binds `os` (a missed repair, never a wrong accept).
+
+Observed residual (1/7, not repaired here): import-guard boilerplate —
+tests wrapping the deliverable import in try/except and asserting
+`False, "<module> not found or function not implemented"` in the guard,
+which fails both rounds identically (turn1_sv2). Deterministic signature
+exists (strip the guard, let a real ImportError report honestly); left
+for ladder evidence to justify.
+
+One rewrite-ambiguity note for reviewers: a test whose handler declares
+"Expected FileNotFoundError" but whose NAME says "returns empty list"
+(self-contradictory authorship, turn6_sv5 r1) rewrites per the declared
+message, fails against return-empty code, and converges via the held
+round regenerating raising code. Honest both rounds; the ambiguity costs
+one round, never a wrong accept.

--- a/docs/plans/2026-07-10-test-repair-round-2-design.md
+++ b/docs/plans/2026-07-10-test-repair-round-2-design.md
@@ -1,0 +1,97 @@
+# Deterministic gate repairs, round 2 (test-quality residual)
+
+**Status:** Approved design, 2026-07-10. Evidence:
+`scratchpad test-quality spike, 11 live replays × qwen3:8b` — findings
+mirrored below; raw dumps retained per spike-retention discipline at the
+session scratchpad (`test-quality-spike/`).
+
+## Evidence (what the spike measured)
+
+11 replays of the battery's two failing build turns (turn1 ×6, turn6 ×5),
+per-round capture inside the loop primitive. Accept base rate: turn1 4/6
+round-1 (5/6 by round 2), turn6 2/5 round-1, 3/5 never. The held TDD
+retry converted **0/4** — every held round carried an unsatisfiable test
+or timed out. Across 8 captured rejected rounds: **code wrong 0,
+spec-freedom divergence 0, over-specified assertions 0.** The classes,
+with counts:
+
+1. **Undefined helper name in tests ×3** — `assert file_exists(...)`
+   (NameError; a call to a name bound nowhere — the bare-name sanitizer
+   and import injection cannot reach it).
+2. **Unconditional `os.remove` setup crash ×2** — setup deletes a file
+   that does not exist in the fresh per-test sandbox.
+3. **Inverted exception-expectation block ×2 (+1 co-cause)** — the test
+   fails a correct implementation that raises as specified.
+4. **Adequacy false-reject of mutation-style tests ×1 (+1 contributory)**
+   — `add_todo(todos, "x"); assert todos == ["x"]` carries value but the
+   value-bearing-assert rule does not count it; the false-reject
+   cascaded into a worse fresh resample.
+5. **Held-round code_writer timeout ×1** — `build-code-round.yaml`'s
+   `code_writer` has no `timeout_seconds`; the 3-call code-generator ran
+   under the 300s default on the system's longest input, shipped empty
+   code, and turned the one genuinely convertible retry into a
+   guaranteed reject.
+
+## Decision
+
+Extend the shipped deterministic repair layer (v0.18.7's isolation +
+sanitizer + import injection) with the four repairs the evidence names,
+plus the two non-repair fixes. No model judgment added anywhere
+(structure beats tiers, measured twice).
+
+1. **Config:** `timeout_seconds: 600` on `build-code-round.yaml`'s
+   `code_writer` (bounded by the dispatch/loop budget above it).
+2. **Adequacy fix:** `adequacy_check.py` counts a mutation-pattern
+   assert as value-bearing — an assert comparing a name to a literal
+   after that name was passed to a call in the same test body.
+3. **New deterministic repairs** (AST-grounded, in the gather/sanitizer
+   layer, echoed into the shipped artifact like the existing repairs):
+   a. **Unbound-callable excision:** a test function that CALLS a name
+      bound nowhere (not module, not import, not defined in tests or
+      code, not a builtin) is excised per-test. No name mapping —
+      guessing `file_exists → os.path.exists` risks changing intent;
+      excision is honest. The executor already runs per-test isolated;
+      3+ of 4–6 tests were good in every observed case.
+   b. **Unguarded-removal guard:** a bare `os.remove(<literal>)` /
+      `os.unlink(<literal>)` statement (not inside try/with) is wrapped
+      in `contextlib.suppress(FileNotFoundError)` (import injected).
+   c. **Inverted exception-expectation rewrite:** the observed
+      anti-pattern (a test body that calls the target inside
+      `try/except <E>` and asserts failure IN the except path, or
+      asserts `False` after an expected-raise call) rewrites to the
+      canonical `with pytest.raises(<E>):` form. Only exact AST
+      signatures rewrite; anything ambiguous is left alone.
+4. **Adequacy re-check after excision:** repairs run BEFORE the
+   adequacy check; if excision leaves no value-bearing test, the round
+   still rejects honestly (the gate never gets weaker than "at least
+   one adequate test ran").
+
+## Bounds
+
+- Every repair has an exact static signature; no heuristic rewrites.
+- Repairs are echoed into the shipped test artifact (the client sees
+  what actually ran — the v0.18.7 convention).
+- Excision is bounded: if it would drop ALL tests, reject unchanged.
+- The wrong-accept class is the review target (v0.18.7 lesson): every
+  repair must be provably behavior-preserving for correct tests — the
+  reviewer brief names this explicitly.
+
+## Ruled out by the evidence
+
+Elicit-then-build (0/8 spec-freedom), code-first ordering swap (code was
+right 7/7 non-timeout), N-sample test voting (the dominant defect is a
+systematic verbatim tic voting would retain, at k× rig cost), model
+escalation (still dead, consistent with the 4-arm spike).
+
+## Follow-up filed separately
+
+Accepted-artifact quality is ungated (an accepted round carried a
+duplicated `def` with junk empty-string behavior) — issue to open, not
+this PR.
+
+## Validation
+
+TDD per repair with the spike's verbatim exemplars as fixtures; full
+suite; live replay of the two spike turns (expect turn6's never-accept
+rate to drop); recorded ladder rerun + trajectory row; independent
+adversarial review with the wrong-accept class as the named target.

--- a/docs/serving-roadmap.md
+++ b/docs/serving-roadmap.md
@@ -34,6 +34,8 @@ model as the backend. Trajectory so far:
 | 2026-07-09 (seat-quality arc) | 10-turn recorded ladder, same seed | **7/10** | Every targeted class converted: memory question routes to explain and answers accurately (decider fix); the storage rung ships (isolation + sanitizer + import injection); its downstream cascade unblocks and the persistence integration is real (todo.py imports storage). Misses: 2 honest build rejects (thinner round-1 test-quality residual) and the known #82 deep-recall deferral. Regression probes: probe 1 accepts attempt 1, probe 2 within two |
 | 2026-07-10 (#83 run half) | 11-turn recorded ladder (run rung added; session resumed at turn 6 after an external process stop — continuity held on the append-only wire) | **6/11** | New rungs both green: turn 8 read→gated tests (client-run green), turn 11 delegated `pytest -q` with the verdict matching client ground truth exactly (6 passed); turn 9 honest phantom refusal. Misses: 3 honest build rejects (turns 2/4/6 — the stochastic 8b test-quality residual, 2–3 per run) plus turn 7 as their honest cascade, and the known #82 deep-recall miss. Zero dishonest outcomes; routing fired correctly on all 11 turns |
 | 2026-07-10 (fenced block grammar) | 11-turn recorded ladder, same battery | **5/11** | No fencing-attributable regression: all 11 routings fired correctly, read rung green, run rung verdict matched ground truth (6 passed), phantom refusal honest. Turn 1's honest build reject cascaded (turns 2/3/4/7 degrade downstream, deep recall skews) — run-to-run variance is dominated by whether turn 1 lands, i.e. the test-quality residual, now clearly the highest-leverage target. Spoof battery (separate live session): a read file carrying a forged "999 passed" transcript block could NOT suppress the real run — real delegation, honest red verdict |
+| 2026-07-10 (repairs round 2, pre-review-fix) | 11-turn recorded ladder | **9/11** | Best recorded score. The deterministic repairs (excision, removal guard, raises rewrite, adequacy mutation fix, retry timeout) converted the whole build cascade: turns 1/2/4/6 all shipped. Misses: turn 7 honest reject (the persist-integration shape) and #82 deep recall. Replay evidence behind the repairs: turn6 3/3 round-1 accepts vs 2/5-with-3-never at baseline |
+| 2026-07-10 (repairs round 2, post-review-fix) | 11-turn recorded ladder (resumed at turn 6 after a harness process reap; detached runner thereafter) | **6/11** | Three wrong-accept vectors from the adversarial review closed pre-merge (substring expectation match, anywhere-in-body removal wrap, lambda-param binding blindness) — the fixes are deliberately conservative and refuse ambiguous rewrites, trading conversions for gate honesty. 3 honest build rejects + cascade + #82. Named follow-up with evidence: tighten the negation refusal to expectation-adjacent tokens ("Expected TypeError not raised" currently refuses) |
 
 The Cycle-7 benchmark harness (`research/agentic-serving-corpus` branch,
 `benchmark-runs/`) is the automation to revive for a standing
@@ -100,22 +102,27 @@ deterministic accept gate (per-test-isolated executor + static adequacy
 into the shipped artifact). All-local (qwen3:8b) by default; operator
 seat overrides via `*.local.yaml`.
 
-**Handoff pointer (fresh-session start here):** block-body fencing
-SHIPPED (v0.18.9 — the pre-meta-task blocker is closed; the spoof class
-is dead at unit, engine, and live levels). NEXT, in leverage order: the
-**build test-quality residual** (2–3 honest rejects per 11-turn run is
-now clearly the dominant score cost — turn 1's reject cascades through
-half the battery; the residual class is round-1 authored-test quality on
-the 8b seat, and the named next lever is structural per the 2026-07-09
-finding: shape change or escalation-on-signal, not a third prompt rule),
-then **#83 discovery** (list/glob through the same seam — the meta-task
-rung's requirement, now unblocked by fencing), then the #82 deep-recall
-remainder (still costs a ladder turn every run). The recorded battery is
-`benchmarks/agentic_serving/ladder_battery.sh` (11 turns; last scores
-6/11 and 5/11, every miss honest, variance dominated by turn 1's build).
-Standing smaller follow-ups: the injector's scope-blind binding, #107
-(content-parts message content crashes the render path — pre-existing),
-#106 (shape single-home + silent dispatch trace errors).
+**Handoff pointer (fresh-session start here):** deterministic gate
+repairs round 2 SHIPPED (v0.18.10; design + evidence
+`docs/plans/2026-07-10-test-repair-round-2-design.md` — 11 live replays
+proved code wrong in 0/8 rejected rounds; the repairs attack the tests).
+NEXT, in leverage order: **#83 discovery** (list/glob through the
+permission seam — the meta-task rung's requirement, unblocked by
+fencing), the **rewrite negation-tightening** (expectation-adjacent
+tokens only; "Expected TypeError not raised" currently refuses the
+rewrite and costs a round — exact evidence in the design doc's second
+review round), the **#82 deep-recall remainder** (still costs a ladder
+turn every run), and the import-guard residual (turn1_sv2 class, one
+deterministic signature away). The recorded battery is
+`benchmarks/agentic_serving/ladder_battery.sh` (11 turns; series 4/10 →
+7/10 → 6/11 → 5/11 → 9/11 → 6/11, every miss honest — variance is
+per-run seat stochasticity on the build turns). Standing smaller
+follow-ups: #110 (accepted-artifact quality gate + adequacy mutator
+tightening), the injector's scope-blind binding, #107 (content-parts
+crash class), #106 (shape single-home + silent dispatch trace errors).
+Ops note: the harness reaps tracked background serves/batteries
+mid-long-run — start them detached (nohup + disown) with a Monitor on
+the log file.
 
 Key empirical facts the next work builds on:
 

--- a/tests/unit/serving/test_adequacy_check.py
+++ b/tests/unit/serving/test_adequacy_check.py
@@ -80,6 +80,53 @@ def test_expected_value_derived_from_the_same_call_is_tautological() -> None:
     assert verdict["tests_adequate"] is False
 
 
+def test_mutation_pattern_assert_is_value_bearing() -> None:
+    """The spike's turn1_s5 r1 false-reject (2026-07-10): a None-returning
+    mutator is verified by passing a local to the call and comparing that
+    local to an independent literal afterwards. For a task shaped 'add an
+    item to a list', mutation style is the natural correct test."""
+    verdict = _check(
+        "add_todo",
+        "def add_todo(todos, item):\n    todos.append(item)",
+        'def test_add():\n    todos = []\n    add_todo(todos, "x")\n'
+        '    assert todos == ["x"]',
+    )
+    assert verdict["tests_adequate"] is True
+
+
+def test_mutation_pattern_subscript_assert_is_value_bearing() -> None:
+    verdict = _check(
+        "add_todo",
+        "def add_todo(todos, item):\n    todos.append(item)",
+        'def test_add():\n    todos = []\n    add_todo(todos, "x")\n'
+        '    assert todos[0] == "x"',
+    )
+    assert verdict["tests_adequate"] is True
+
+
+def test_compare_of_two_untouched_names_is_not_value_bearing() -> None:
+    """A compare with no call anywhere in the body stays inadequate — the
+    mutation rule needs the name to have been passed to a real call first."""
+    verdict = _check(
+        "add_todo",
+        "def add_todo(todos, item):\n    todos.append(item)",
+        'def test_add():\n    todos = ["x"]\n    assert todos == ["x"]',
+    )
+    assert verdict["tests_adequate"] is False
+
+
+def test_mutation_compare_against_a_non_literal_is_not_value_bearing() -> None:
+    """Comparing the mutated name to another plain name is not an
+    independent expected value — only literals/containers count."""
+    verdict = _check(
+        "add_todo",
+        "def add_todo(todos, item):\n    todos.append(item)",
+        "def test_add():\n    todos = []\n    expected = todos\n"
+        '    add_todo(todos, "x")\n    assert todos == expected',
+    )
+    assert verdict["tests_adequate"] is False
+
+
 def test_unittest_assert_methods_are_value_bearing() -> None:
     verdict = _check(
         "add",

--- a/tests/unit/serving/test_adequacy_check.py
+++ b/tests/unit/serving/test_adequacy_check.py
@@ -23,6 +23,7 @@ import yaml
 
 REPO = Path(__file__).resolve().parents[3]
 CHECK = REPO / ".llm-orc" / "scripts" / "agentic_serving" / "adequacy_check.py"
+EXECUTOR = REPO / ".llm-orc" / "scripts" / "agentic_serving" / "accept_executor.py"
 FIXTURES = REPO / "benchmarks" / "judge_adequacy" / "fixtures.yaml"
 
 
@@ -219,6 +220,53 @@ def test_unparseable_tests_are_inadequate_not_a_crash() -> None:
     verdict = _check("f", "def f():\n    return 1", "def test_(:\n    broken")
     assert verdict["tests_adequate"] is False
     assert "parse" in verdict["reason"]
+
+
+def test_adequacy_judges_the_repaired_suite_not_the_raw_one() -> None:
+    """Ordering (round-2 repairs, 2026-07-10): the judge reads the
+    executor's ECHOED contract, so repairs run before the adequacy check.
+    The inverted exception-expectation suite is inadequate raw (no failure
+    signal in the try body) but adequate once the executor rewrites it to
+    pytest.raises — the repaired suite is what gets judged."""
+    code = (
+        "def save_todos(todos):\n"
+        "    if todos is None:\n"
+        "        raise TypeError('todos must be a list')\n"
+    )
+    tests = (
+        "def test_save_todos_handles_exceptions():\n"
+        "    try:\n"
+        "        save_todos(None)\n"
+        "    except TypeError:\n"
+        '        assert False, "Expected TypeError"\n'
+        "    else:\n"
+        '        assert False, "Did not raise TypeError"\n'
+    )
+    raw_verdict = _check("save todos", code, tests)
+    assert raw_verdict["tests_adequate"] is False
+
+    executor_out = subprocess.run(
+        [sys.executable, str(EXECUTOR)],
+        input=json.dumps({"requirement": "save todos", "code": code, "tests": tests}),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    payload = json.dumps(
+        {
+            "input_data": "save todos",
+            "dependencies": {"executor": {"response": executor_out}},
+        }
+    )
+    out = subprocess.run(
+        [sys.executable, str(CHECK)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    chained: dict[str, Any] = json.loads(out)
+    assert chained["tests_adequate"] is True
 
 
 def test_verdict_shape_matches_the_judge_contract() -> None:

--- a/tests/unit/serving/test_serving_accept_executor_runner.py
+++ b/tests/unit/serving/test_serving_accept_executor_runner.py
@@ -52,3 +52,25 @@ def test_no_flag_keeps_legacy_whole_run(tmp_path: Path) -> None:
     verdict = _run(CODE, LEAKY_TESTS, tmp_path)
     assert verdict["n_tests"] == 2
     assert verdict["tests_pass"] is False  # the shared-state leak, as today
+
+
+def test_pytest_raises_did_not_raise_reports_as_failure_not_crash(
+    tmp_path: Path,
+) -> None:
+    """pytest.fail's Failed derives from BaseException, so the repaired
+    pytest.raises form (test-repair round 2) crashed the runner child on
+    DID NOT RAISE instead of reporting a clean per-test failure — a
+    fail-closed defect that starved the retry round of evidence
+    (validation replay turn6_sv5 r1, 2026-07-10)."""
+    code = "def load_todos():\n    return []\n"
+    tests = (
+        "import pytest\n\n"
+        "def test_missing_file_raises():\n"
+        "    with pytest.raises(FileNotFoundError):\n"
+        "        load_todos()\n"
+    )
+    verdict = _run(code, tests, tmp_path)
+    assert verdict["tests_pass"] is False
+    assert verdict["n_tests"] == 1
+    assert "DID NOT RAISE" in verdict["report"]
+    assert "runner crashed" not in verdict["report"]

--- a/tests/unit/serving/test_serving_accept_gate.py
+++ b/tests/unit/serving/test_serving_accept_gate.py
@@ -465,6 +465,33 @@ def test_excision_that_would_drop_all_tests_leaves_the_suite_unchanged() -> None
     assert result["tests_pass"] is False
 
 
+def test_excised_to_empty_suite_still_rejects_at_the_gate() -> None:
+    """The gate never gets weaker than 'at least one adequate test ran':
+    when every test calls an unbound name, excision declines, the raw
+    suite NameErrors in the executor, and the round rejects regardless of
+    the judge's adequacy verdict on the echoed tests."""
+    executor_resp = _executor(
+        "save/load todos", _SAVE_LOAD_CODE, _UNBOUND_CALLABLE_TEST
+    )
+    check = REPO / ".llm-orc" / "scripts" / "agentic_serving" / "adequacy_check.py"
+    payload = json.dumps(
+        {
+            "input_data": "save/load todos",
+            "dependencies": {"executor": {"response": json.dumps(executor_resp)}},
+        }
+    )
+    judge_out = subprocess.run(
+        [sys.executable, str(check)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    verdict = _gate(executor_resp, json.loads(judge_out))
+    assert verdict["accept"] is False
+    assert verdict["tests_pass"] is False
+
+
 def test_call_to_a_code_bound_name_is_never_excised() -> None:
     result = _executor("save/load todos", _SAVE_LOAD_CODE, _GOOD_ROUNDTRIP_TEST)
     assert result["tests_excised"] == 0

--- a/tests/unit/serving/test_serving_accept_gate.py
+++ b/tests/unit/serving/test_serving_accept_gate.py
@@ -714,3 +714,93 @@ def test_dotted_exception_without_declared_expectation_stays() -> None:
     result = _executor("load todos", code, tests)
     assert result["tests_raises_rewritten"] == 0
     assert "pytest.raises" not in result["tests"]
+
+
+def test_unexpected_message_guard_is_never_rewritten() -> None:
+    """Review probe P1d (2026-07-10): 'Unexpected ValueError' contains the
+    substring 'expected' — a correct must-not-raise guard that the rewrite
+    inverted, accepting wrong code that raises. The declaration check must
+    be a positive whole word."""
+    tests = (
+        "def test_save_never_raises():\n"
+        "    try:\n"
+        "        save_todos([1])\n"
+        "    except ValueError:\n"
+        '        assert False, "Unexpected ValueError"\n'
+    )
+    raising_code = "def save_todos(todos):\n    raise ValueError('nope')\n"
+    result = _executor("save todos", raising_code, tests)
+    assert result["tests_raises_rewritten"] == 0
+    assert result["tests_pass"] is False
+
+
+def test_declared_name_must_match_the_caught_exception_whole_word() -> None:
+    """Review probe (2026-07-10): 'Error' is a substring of 'KeyError', so a
+    handler catching a custom Error with a message declaring KeyError
+    rewrote to pytest.raises(Error) and accepted code raising the wrong
+    exception."""
+    tests = (
+        "class Error(Exception):\n"
+        "    pass\n\n"
+        "def test_lookup_raises_keyerror():\n"
+        "    try:\n"
+        "        lookup({})\n"
+        "    except Error:\n"
+        '        assert False, "Expected KeyError"\n'
+    )
+    code = (
+        "class Error(Exception):\n"
+        "    pass\n\n"
+        "def lookup(d):\n"
+        "    raise Error('wrong class')\n"
+    )
+    result = _executor("lookup", code, tests)
+    assert result["tests_raises_rewritten"] == 0
+
+
+def test_post_call_removal_is_not_wrapped() -> None:
+    """Review probe P2b (2026-07-10): an os.remove AFTER the code call is an
+    implicit the-file-was-created assertion — wrapping it in suppress
+    neutered the only check and accepted code that never writes. Only
+    setup-position removals (before any code-bound reference) wrap."""
+    tests = (
+        "import os\n\n"
+        "def test_save_creates_file():\n"
+        "    save_todos([1])\n"
+        '    os.remove("todos.json")\n'
+    )
+    lazy_code = "def save_todos(todos):\n    pass\n"
+    result = _executor("save todos", lazy_code, tests)
+    assert result["tests_removals_guarded"] == 0
+    assert result["tests_pass"] is False
+
+
+def test_setup_position_removal_still_wraps() -> None:
+    tests = (
+        "import os\n\n"
+        "def test_load_missing_returns_empty():\n"
+        '    os.remove("todos.json")\n'
+        "    assert load_todos() == []\n"
+    )
+    code = "def load_todos():\n    return []\n"
+    result = _executor("load todos", code, tests)
+    assert result["tests_removals_guarded"] == 1
+    assert result["tests_pass"] is True
+
+
+def test_lambda_parameters_are_bound_names_for_excision() -> None:
+    """Review probe P3b (2026-07-10): _bound_names missed lambda params, so
+    'apply = lambda g: g(5)' looked like a call to unbound g and the one
+    test catching wrong code was silently excised — the v0.18.7
+    for/with/walrus analogue."""
+    tests = (
+        "def test_square_applies():\n"
+        "    apply = lambda g: g(5)\n"
+        "    assert apply(square) == 25\n\n"
+        "def test_square_zero():\n"
+        "    assert square(0) == 0\n"
+    )
+    wrong_code = "def square(x):\n    return x + x\n"
+    result = _executor("square", wrong_code, tests)
+    assert result["tests_excised"] == 0
+    assert result["tests_pass"] is False

--- a/tests/unit/serving/test_serving_accept_gate.py
+++ b/tests/unit/serving/test_serving_accept_gate.py
@@ -471,6 +471,56 @@ def test_call_to_a_code_bound_name_is_never_excised() -> None:
     assert result["tests_pass"] is True
 
 
+def test_unguarded_os_remove_is_wrapped_in_suppress() -> None:
+    """Verbatim spike exemplar (turn6_s4 r1+r2): setup deletes a file that
+    never exists in the fresh per-test sandbox; FileNotFoundError fires
+    before the assert. The wrap makes setup idempotent without touching
+    what the test asserts about the code."""
+    tests = (
+        "def test_load_todos_returns_empty_list_on_missing_file():\n"
+        "    import os\n"
+        '    os.remove("todos.json")\n'
+        "    assert load_todos() == []\n"
+    )
+    result = _executor("save/load todos", _SAVE_LOAD_CODE, tests)
+    assert result["tests_removals_guarded"] == 1
+    assert "with contextlib.suppress(FileNotFoundError):" in result["tests"]
+    assert "import contextlib" in result["tests"]
+    assert result["tests_pass"] is True
+
+
+def test_os_unlink_is_guarded_like_os_remove() -> None:
+    tests = (
+        "import os\n"
+        "def test_missing_file():\n"
+        '    os.unlink("todos.json")\n'
+        "    assert load_todos() == []\n"
+    )
+    result = _executor("save/load todos", _SAVE_LOAD_CODE, tests)
+    assert result["tests_removals_guarded"] == 1
+    assert result["tests_pass"] is True
+
+
+def test_removal_already_inside_try_or_with_is_left_alone() -> None:
+    tests = (
+        "import os\n"
+        "import contextlib\n"
+        "def test_missing_file():\n"
+        "    with contextlib.suppress(FileNotFoundError):\n"
+        '        os.remove("todos.json")\n'
+        "    assert load_todos() == []\n"
+        "def test_missing_file_try():\n"
+        "    try:\n"
+        '        os.remove("todos.json")\n'
+        "    except FileNotFoundError:\n"
+        "        pass\n"
+        "    assert load_todos() == []\n"
+    )
+    result = _executor("save/load todos", _SAVE_LOAD_CODE, tests)
+    assert result["tests_removals_guarded"] == 0
+    assert result["tests_pass"] is True
+
+
 def test_call_to_a_fixture_parameter_is_never_excised() -> None:
     """A called name bound as a test parameter (pytest fixture) is bound."""
     tests = (

--- a/tests/unit/serving/test_serving_accept_gate.py
+++ b/tests/unit/serving/test_serving_accept_gate.py
@@ -521,6 +521,118 @@ def test_removal_already_inside_try_or_with_is_left_alone() -> None:
     assert result["tests_pass"] is True
 
 
+# --- inverted exception-expectation rewrite (spike 2026-07-10) ---
+
+_RAISING_SAVE = (
+    "def save_todos(todos):\n"
+    "    if todos is None:\n"
+    "        raise TypeError('todos must be a list')\n"
+    "    return list(todos)\n"
+)
+
+
+def test_inverted_expectation_with_both_branches_false_is_rewritten() -> None:
+    """Verbatim spike exemplar (turn6_s2 r1+r2): both branches assert
+    False — no implementation can pass, and the code that correctly
+    raised TypeError was punished for it. The messages name the intent
+    (raise expected); rewrite to the canonical pytest.raises form."""
+    tests = (
+        "def test_save_todos_handles_exceptions():\n"
+        "    try:\n"
+        "        save_todos(None)\n"
+        "    except TypeError:\n"
+        '        assert False, "Expected TypeError"\n'
+        "    else:\n"
+        '        assert False, "Did not raise TypeError"\n'
+    )
+    result = _executor("save todos", _RAISING_SAVE, tests)
+    assert result["tests_raises_rewritten"] == 1
+    assert "with pytest.raises(TypeError):" in result["tests"]
+    assert "import pytest" in result["tests"]
+    assert result["tests_pass"] is True
+
+
+def test_inverted_expectation_with_bare_handler_and_true_else_rewrites() -> None:
+    """Verbatim spike exemplar (turn1_s5 r2): the specific handler asserts
+    False with 'expected ValueError', a bare handler asserts False, and
+    the else is a vacuous assert True — the assert-False belongs after
+    the call / in else, exactly the positional garble the prompt rule
+    tried to teach."""
+    code = (
+        "def add_todo(item):\n"
+        "    if item is None:\n"
+        "        raise ValueError('item required')\n"
+    )
+    tests = (
+        "def test_add_todo_raises_value_error_for_none():\n"
+        "    try:\n"
+        "        add_todo(None)\n"
+        "    except ValueError as e:\n"
+        '        assert False, "expected ValueError"\n'
+        "    except:\n"
+        '        assert False, "unexpected exception"\n'
+        "    else:\n"
+        '        assert True, "no exception raised"\n'
+    )
+    result = _executor("add todo", code, tests)
+    assert result["tests_raises_rewritten"] == 1
+    assert "with pytest.raises(ValueError):" in result["tests"]
+    assert result["tests_pass"] is True
+
+
+def test_expectation_with_a_real_else_assert_is_left_alone() -> None:
+    """turn6_s5's lookalike: the else carries a real value assert, so the
+    test is satisfiable by correct non-raising code — rewriting to
+    pytest.raises would BREAK a correct implementation. Ambiguous stays
+    untouched."""
+    tests = (
+        "def test_load_todos_returns_empty_list_if_file_not_found():\n"
+        "    try:\n"
+        "        load_todos()\n"
+        "    except FileNotFoundError:\n"
+        '        assert False, "Expected FileNotFoundError"\n'
+        "    else:\n"
+        "        assert load_todos() == []\n"
+    )
+    result = _executor("save/load todos", _SAVE_LOAD_CODE, tests)
+    assert result["tests_raises_rewritten"] == 0
+    assert result["tests_pass"] is True
+
+
+def test_canonical_expect_raise_try_form_is_left_alone() -> None:
+    """The correct idiom (assert False AFTER the call, handler passes) has
+    an assert in the try body — outside the exact signature."""
+    tests = (
+        "def test_rejects_none():\n"
+        "    try:\n"
+        "        save_todos(None)\n"
+        '        assert False, "expected TypeError"\n'
+        "    except TypeError:\n"
+        "        pass\n"
+    )
+    result = _executor("save todos", _RAISING_SAVE, tests)
+    assert result["tests_raises_rewritten"] == 0
+    assert result["tests_pass"] is True
+
+
+def test_handler_message_that_does_not_declare_expectation_is_left_alone() -> None:
+    """'except E: assert False' whose message does NOT say the raise was
+    expected could be a legitimate must-not-raise guard — ambiguous, so
+    untouched (reject stays honest)."""
+    tests = (
+        "def test_never_raises_for_lists():\n"
+        "    try:\n"
+        "        save_todos([1])\n"
+        "    except TypeError:\n"
+        '        assert False, "should not raise for a list"\n'
+        "    else:\n"
+        "        pass\n"
+    )
+    result = _executor("save todos", _RAISING_SAVE, tests)
+    assert result["tests_raises_rewritten"] == 0
+    assert result["tests_pass"] is True
+
+
 def test_call_to_a_fixture_parameter_is_never_excised() -> None:
     """A called name bound as a test parameter (pytest fixture) is bound."""
     tests = (

--- a/tests/unit/serving/test_serving_accept_gate.py
+++ b/tests/unit/serving/test_serving_accept_gate.py
@@ -671,3 +671,46 @@ def test_call_to_a_fixture_parameter_is_never_excised() -> None:
     )
     result = _executor("adds", "def add(a, b):\n    return a + b\n", tests)
     assert result["tests_excised"] == 0
+
+
+def test_inverted_expectation_with_dotted_exception_is_rewritten() -> None:
+    """Validation replay exemplar (turn6_sv1/sv3/sv4, 2026-07-10): the
+    handler catches the Attribute form ``json.JSONDecodeError`` — the
+    natural spelling for the storage turn — and every sample rejected on
+    it. The declared-expectation check matches the dotted name's last
+    segment; the rewrite emits the dotted form."""
+    code = (
+        "import json\n\n"
+        "def load_todos():\n"
+        '    with open("todos.json") as f:\n'
+        "        return json.loads(f.read())\n"
+    )
+    tests = (
+        "import json\n\n"
+        "def test_load_todos_handles_json_errors():\n"
+        '    with open("todos.json", "w") as f:\n'
+        '        f.write("{not json")\n'
+        "    try:\n"
+        "        load_todos()\n"
+        "    except json.JSONDecodeError:\n"
+        '        assert False, "Expected JSONDecodeError"\n'
+    )
+    result = _executor("load todos", code, tests)
+    assert result["tests_raises_rewritten"] == 1
+    assert "with pytest.raises(json.JSONDecodeError):" in result["tests"]
+    assert result["tests_pass"] is True
+
+
+def test_dotted_exception_without_declared_expectation_stays() -> None:
+    tests = (
+        "import json\n\n"
+        "def test_load_todos_tolerates_bad_json():\n"
+        "    try:\n"
+        "        load_todos()\n"
+        "    except json.JSONDecodeError:\n"
+        '        assert False, "should tolerate bad json"\n'
+    )
+    code = "def load_todos():\n    return []\n"
+    result = _executor("load todos", code, tests)
+    assert result["tests_raises_rewritten"] == 0
+    assert "pytest.raises" not in result["tests"]

--- a/tests/unit/serving/test_serving_accept_gate.py
+++ b/tests/unit/serving/test_serving_accept_gate.py
@@ -406,3 +406,79 @@ def test_unparseable_tests_skip_injection_and_sanitization() -> None:
     assert result["tests_sanitized"] == 0
     assert result["tests_imports_injected"] == 0
     assert result["tests_pass"] is False
+
+
+# --- unbound-callable excision (spike 2026-07-10: `file_exists` tic) ---
+
+_SAVE_LOAD_CODE = (
+    "import json\n"
+    "import os\n"
+    "def save_todos(todos):\n"
+    "    with open('todos.json', 'w') as f:\n"
+    "        json.dump(todos, f)\n"
+    "def load_todos():\n"
+    "    if not os.path.exists('todos.json'):\n"
+    "        return []\n"
+    "    with open('todos.json') as f:\n"
+    "        return json.load(f)\n"
+)
+
+# verbatim spike exemplar (turn6_s2 r1 / turn6_s5 r1+r2): file_exists is
+# bound nowhere — not a module, so import injection cannot reach it
+_UNBOUND_CALLABLE_TEST = (
+    "def test_save_todos_saves_todos_to_file():\n"
+    '    todos = ["Buy groceries", "Walk the dog"]\n'
+    "    save_todos(todos)\n"
+    '    assert file_exists("todos.json")\n'
+)
+
+_GOOD_ROUNDTRIP_TEST = (
+    "def test_load_todos_returns_saved_todos():\n"
+    '    todos = ["Buy groceries", "Walk the dog"]\n'
+    "    save_todos(todos)\n"
+    "    loaded = load_todos()\n"
+    "    assert loaded == todos\n"
+)
+
+
+def test_unbound_callable_test_is_excised_and_the_rest_run() -> None:
+    """A test calling a name bound nowhere (not tests, not code, not a
+    builtin, not injectable) can never run — no code regeneration defines
+    it. Excise that one test, run the remainder, echo the excised suite."""
+    result = _executor(
+        "save/load todos",
+        _SAVE_LOAD_CODE,
+        _UNBOUND_CALLABLE_TEST + _GOOD_ROUNDTRIP_TEST,
+    )
+    assert result["tests_excised"] == 1
+    assert "file_exists" not in result["tests"]
+    assert "test_load_todos_returns_saved_todos" in result["tests"]
+    assert result["tests_pass"] is True
+
+
+def test_excision_that_would_drop_all_tests_leaves_the_suite_unchanged() -> None:
+    """Bound: excising everything would judge an empty suite — leave the
+    suite alone so the round rejects honestly on the real NameError."""
+    result = _executor("save/load todos", _SAVE_LOAD_CODE, _UNBOUND_CALLABLE_TEST)
+    assert result["tests_excised"] == 0
+    assert "file_exists" in result["tests"]
+    assert result["tests_pass"] is False
+
+
+def test_call_to_a_code_bound_name_is_never_excised() -> None:
+    result = _executor("save/load todos", _SAVE_LOAD_CODE, _GOOD_ROUNDTRIP_TEST)
+    assert result["tests_excised"] == 0
+    assert result["tests_pass"] is True
+
+
+def test_call_to_a_fixture_parameter_is_never_excised() -> None:
+    """A called name bound as a test parameter (pytest fixture) is bound."""
+    tests = (
+        "def test_uses_factory(make_thing):\n"
+        "    thing = make_thing()\n"
+        "    assert thing != 0\n"
+        "def test_add():\n"
+        "    assert add(1, 2) == 3\n"
+    )
+    result = _executor("adds", "def add(a, b):\n    return a + b\n", tests)
+    assert result["tests_excised"] == 0

--- a/tests/unit/serving/test_serving_accept_gather.py
+++ b/tests/unit/serving/test_serving_accept_gather.py
@@ -177,6 +177,109 @@ def test_executor_reads_contract_from_gather_dependency() -> None:
     assert result["tests"] == TESTS
 
 
+# --- round-2 repairs, end to end (spike 2026-07-10) ---
+
+JUDGE = REPO / ".llm-orc" / "scripts" / "agentic_serving" / "adequacy_check.py"
+GATE = REPO / ".llm-orc" / "scripts" / "agentic_serving" / "accept_gate.py"
+
+_STORAGE_CODE = (
+    "import json\n"
+    "import os\n"
+    "def save_todos(todos):\n"
+    "    if todos is None:\n"
+    "        raise TypeError('todos must be a list')\n"
+    "    with open('todos.json', 'w') as f:\n"
+    "        json.dump(todos, f)\n"
+    "def load_todos():\n"
+    "    if not os.path.exists('todos.json'):\n"
+    "        return []\n"
+    "    with open('todos.json') as f:\n"
+    "        return json.load(f)\n"
+)
+
+# one good test + the three spike defect classes, over CORRECT code
+_COMPOSITE_TESTS = (
+    "def test_roundtrip():\n"
+    '    save_todos(["Buy groceries"])\n'
+    '    assert load_todos() == ["Buy groceries"]\n'
+    "def test_save_todos_saves_todos_to_file():\n"
+    '    todos = ["Buy groceries", "Walk the dog"]\n'
+    "    save_todos(todos)\n"
+    '    assert file_exists("todos.json")\n'
+    "def test_load_todos_returns_empty_list_on_missing_file():\n"
+    "    import os\n"
+    '    os.remove("todos.json")\n'
+    "    assert load_todos() == []\n"
+    "def test_save_todos_handles_exceptions():\n"
+    "    try:\n"
+    "        save_todos(None)\n"
+    "    except TypeError:\n"
+    '        assert False, "Expected TypeError"\n'
+    "    else:\n"
+    '        assert False, "Did not raise TypeError"\n'
+)
+
+
+def _script(script: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    out = subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    result: dict[str, Any] = json.loads(out)
+    return result
+
+
+def test_composite_defective_suite_over_correct_code_accepts_repaired() -> None:
+    """The round-2 repair layer end to end (spike 2026-07-10): a suite
+    carrying the three observed defect classes plus one good test, over
+    correct code, flows gather -> executor -> judge -> gate and ACCEPTS —
+    the unbound-callable test excised, the unguarded remove suppressed,
+    the inverted expectation rewritten, and the shipped artifact carrying
+    exactly the surviving/repaired tests."""
+    criteria = "Write save_todos(todos) and load_todos() in storage.py"
+    gathered = _gather(
+        criteria,
+        "```python\n" + _COMPOSITE_TESTS + "```",
+        "```python\n" + _STORAGE_CODE + "```",
+    )
+    executor_resp = _executor_from_gather(gathered)
+
+    assert executor_resp["tests_excised"] == 1
+    assert executor_resp["tests_removals_guarded"] == 1
+    assert executor_resp["tests_raises_rewritten"] == 1
+    assert executor_resp["tests_pass"] is True, executor_resp["report"]
+    assert executor_resp["n_tests"] == 3
+
+    repaired = executor_resp["tests"]
+    assert "file_exists" not in repaired
+    assert "with contextlib.suppress(FileNotFoundError):" in repaired
+    assert "with pytest.raises(TypeError):" in repaired
+    assert "test_roundtrip" in repaired
+
+    judge_resp = _script(
+        JUDGE,
+        {
+            "input_data": criteria,
+            "dependencies": {"executor": {"response": json.dumps(executor_resp)}},
+        },
+    )
+    assert judge_resp["tests_adequate"] is True
+
+    verdict = _script(
+        GATE,
+        {
+            "dependencies": {
+                "executor": {"response": json.dumps(executor_resp)},
+                "judge": {"response": json.dumps(judge_resp)},
+            }
+        },
+    )
+    assert verdict["accept"] is True, verdict
+
+
 def test_gather_strips_conversation_context_from_the_requirement() -> None:
     """With rung-1 context threading, the shape's base input carries the
     conversation ahead of the 'Current request:' marker. The requirement the

--- a/tests/unit/serving/test_serving_build_round.py
+++ b/tests/unit/serving/test_serving_build_round.py
@@ -108,6 +108,18 @@ def test_build_gated_loop_body_is_the_router() -> None:
     assert round_agent.loop.body == "build-round"
 
 
+def test_build_code_round_code_writer_has_timeout_headroom() -> None:
+    """The held-round input is the system's longest prompt (turn + reject
+    report + held tests); the 300s default timed out the 3-call
+    code-generator, shipped empty code, and killed the one convertible
+    retry (spike 2026-07-10). The node needs explicit headroom, bounded
+    by the dispatch/loop budget above it."""
+    config = _load("build-code-round")
+    assert config is not None
+    writer = next(a for a in config.agents if a.name == "code_writer")
+    assert writer.timeout_seconds == 600
+
+
 def test_build_code_round_has_no_test_writer_and_gate_reads_gather() -> None:
     """The held round: code-only against the carried spec; the gate carries
     round 1's adequacy from gather's held flag (no judge seat)."""


### PR DESCRIPTION
## What

Extends the accept gate's deterministic repair layer with the classes an 11-replay live spike measured (code wrong in **0 of 8** rejected rounds — the authored tests were at fault every time):

- **Unbound-callable test excision** (`assert file_exists(...)` NameErrors no code can fix) — per-test, bounded so an excised-to-empty suite still rejects
- **Setup-position `os.remove`/`os.unlink` suppress-wrap** (per-test sandbox isolation made fresh-dir deletes crash before any assert)
- **Inverted exception-expectation rewrite** to `pytest.raises` (bare and dotted exception forms), exact AST signature with a positive whole-word expectation declaration
- **Adequacy fix:** mutation-pattern asserts count as value-bearing (a measured false-reject that cascaded into worse resamples)
- **Retry unblocked:** the held round's code_writer ran under the 300s default on the system's longest input, shipping empty code — the one convertible retry class never converted; now 600s
- **Runner fix:** pytest outcome exceptions (DID-NOT-RAISE) report as per-test failures instead of crashing the child

Design + full evidence trail: `docs/plans/2026-07-10-test-repair-round-2-design.md` (spike classification, validation round, both review rounds).

## Review record (two independent passes, wrong-accept as the named target)

**Validation replays** (same driver, repaired branch): turn6 went from 2/5-accept-with-3-never-converging to **3/3 round-1 accepts**; repairs observed firing in flight; two defects found and fixed (runner crash on DID-NOT-RAISE; dotted-form coverage gap).

**Independent adversarial review:** initial verdict REQUEST-CHANGES with **three confirmed wrong-accepts**, each driven end-to-end: substring expectation matching ("Unexpected ValueError" inverted a correct must-not-raise guard; "Error" matched inside "KeyError"), anywhere-in-body removal wrapping (neutered post-call existence assertions), and lambda-param binding blindness (excised the one good test). All three fixed with the reviewer's probes pinned as regression tests; re-review verdict **APPROVE** (all probes honest in both directions, positive controls still fire, new seams verified fail-closed). Adequacy mutator tightening deferred with reasons to #110.

## Ladder evidence

Recorded series today: 5/11 (pre) → **9/11** (repairs, best recorded) → 6/11 (post-review-fix, conservative rewrites refusing ambiguity). Every miss in every run is an honest reject/refusal; the named follow-up (negation-tightening) has its exact evidence in the design doc. Full suite 2759 green, 91.8% coverage.

Issues: #110 (artifact quality + adequacy tightening), import-guard residual in the roadmap handoff.
