### PR TITLE
Content-parts wire robustness at the endpoint boundary (#107)

### DIFF
--- a/docs/serving-roadmap.md
+++ b/docs/serving-roadmap.md
@@ -131,9 +131,10 @@ follow-ups: #110, the injector's scope-blind binding, #106, the serve
 trace's ~280-char node-response truncation (blocks post-hoc held-round
 diagnosis), and the glob-result verbatim wire capture (the wire log is
 shape-only — a capture needs a body-dumping probe, not
-LLM_ORC_SERVE_WIRE_LOG). #107 is fixed on branch
-`worktree-fix-107-content-parts` (endpoint-boundary normalizer — the
-422 fired at pydantic before the caller could crash). Ops notes: the
+LLM_ORC_SERVE_WIRE_LOG). #107 is fixed (PR #113:
+endpoint-boundary `_text_content` normalizer — the 422 fired at
+pydantic before the caller could crash; textless/malformed parts
+lists still 422 honestly rather than sliding the turn boundary). Ops notes: the
 harness reaps tracked background serves/batteries mid-long-run — start
 them detached (nohup + disown) with a Monitor tail; give the rig
 cooling headroom between batteries.

--- a/docs/serving-roadmap.md
+++ b/docs/serving-roadmap.md
@@ -37,6 +37,7 @@ model as the backend. Trajectory so far:
 | 2026-07-10 (repairs round 2, pre-review-fix) | 11-turn recorded ladder | **9/11** | Best recorded score. The deterministic repairs (excision, removal guard, raises rewrite, adequacy mutation fix, retry timeout) converted the whole build cascade: turns 1/2/4/6 all shipped. Misses: turn 7 honest reject (the persist-integration shape) and #82 deep recall. Replay evidence behind the repairs: turn6 3/3 round-1 accepts vs 2/5-with-3-never at baseline |
 | 2026-07-10 (repairs round 2, post-review-fix) | 11-turn recorded ladder (resumed at turn 6 after a harness process reap; detached runner thereafter) | **6/11** | Three wrong-accept vectors from the adversarial review closed pre-merge (substring expectation match, anywhere-in-body removal wrap, lambda-param binding blindness) — the fixes are deliberately conservative and refuse ambiguous rewrites, trading conversions for gate honesty. 3 honest build rejects + cascade + #82. Named follow-up with evidence: tighten the negation refusal to expectation-adjacent tokens ("Expected TypeError not raised" currently refuses) |
 | 2026-07-10 (#83 discovery) | 12-turn recorded ladder (discovery rung added) | **3/12, infra-degraded** | The rung this battery validates PASSED clean: turn 12 globbed the unnamed metrics module, read the match, shipped test_metrics.py (green client-side). Run rung honest ("no tests ran" — accurate at that moment), phantom refusal honest. The rest is rig exhaustion after six batteries in one day: four turns timed out with EMPTY output (not rejects — the request died client- or model-side), cascading the todo chain. Zero dishonest outcomes. NOT comparable to the series; fresh-rig rerun is the next session's first act. Separate live probes (same code): 1-match chain, 0-match refusal, 2-match refusal all green |
+| 2026-07-10 (fresh-rig rerun, v0.18.11) | 12-turn recorded ladder, clean infra (12 turns in 12.5 min, zero timeouts) | **6/12** | All shipped rungs green: memory (turn 5), storage build (6), read→tests (8, 4 green client-side), phantom refusal (9), run delegation (11, verdict matched ground truth), discovery chain (12, glob→read→test_metrics.py green). Misses: turn 1 round-1 reject (code referenced an undefined `todo` name) cascading through 2/3/4/7, and turn 10 deep recall. **Two misses were NOT honest** — a first for the recorded series: turn 3 shipped hedged speculation about the never-built todo.py instead of saying so (grounded-explain gap), and turn 10 confidently named calc-tests as "the first thing built" (wrong under both readings; #82 evidence). Structural readings: turn-1 build success gates 5 of 12 turns, so run-to-run variance ≈ 5 points on one seat sample; the serve trace truncates node responses (~280 chars), leaving the held-round question undiagnosable post-hoc; the wire log is shape-only, so the verbatim glob capture remains outstanding |
 
 The Cycle-7 benchmark harness (`research/agentic-serving-corpus` branch,
 `benchmark-runs/`) is the automation to revive for a standing
@@ -103,26 +104,39 @@ deterministic accept gate (per-test-isolated executor + static adequacy
 into the shipped artifact). All-local (qwen3:8b) by default; operator
 seat overrides via `*.local.yaml`.
 
-**Handoff pointer (fresh-session start here):** #83 is COMPLETE — read,
-run, and discovery halves all shipped (v0.18.6/8/11); the client
-execution surface the fix-execution and meta-task rungs need is in
-place. FIRST ACT next session: a fresh-rig 12-turn battery rerun (the
-last recorded run was infra-degraded after six batteries in one day —
-see the trajectory table). Then, in leverage order: the **fix-execution
-rung itself** (chain write → run → verdict inside one fix turn — every
-seam exists, this is composition), the **rewrite negation-tightening**
-(expectation-adjacent tokens only; exact evidence in
+**Handoff pointer (fresh-session start here):** the fresh-rig battery
+rerun is DONE (2026-07-10 late: **6/12 clean**, 12.5 min, zero
+timeouts — see the trajectory table; yesterday's 3/12 was infra, not
+regression). NEXT: the **fix-execution rung** (chain write → run →
+verdict inside one fix turn). The seams are mapped and exactly two
+structural blockers exist: a write continuation is terminal
+(`_resumes_turn` excludes write, `serving_ensemble_caller.py`) and
+classify suppresses the run signal whenever a fix/build verb is present
+(`classify.py` `_route`); the composition is fix-intent writes resume +
+a wrote-block→need-run signal mirroring `has_run_block`→run-verdict.
+The rerun also surfaced, in priority order behind fix-execution: the
+series' first two DISHONEST misses (turn 3 speculated about a
+never-built file — the grounded-explain gap; turn 10 wrong recall —
+#82), and a cross-turn-repair observation (turn 2 could have rebuilt
+the never-built todo.py from conversation intent instead of cascading —
+a detectable deterministic condition; sibling rung to fix-execution,
+not scope creep). Then: **rewrite negation-tightening**
+(expectation-adjacent tokens only;
 `docs/plans/2026-07-10-test-repair-round-2-design.md`), the **#82
 deep-recall remainder**, and the import-guard residual. The recorded
-battery is `benchmarks/agentic_serving/ladder_battery.sh` (12 turns
-since the discovery rung; series 4/10 → 7/10 → 6/11 → 5/11 → 9/11 →
-6/11 → 3/12-infra-degraded, every miss honest). Standing smaller
-follow-ups: #110, the injector's scope-blind binding, #107, #106, and
-the glob-result verbatim wire capture (tolerant normalizer live-proven;
-lock it when a capture lands). Ops notes: the harness reaps tracked
-background serves/batteries mid-long-run — start them detached (nohup +
-disown) with a Monitor tail; give the rig cooling headroom between
-batteries.
+battery is `benchmarks/agentic_serving/ladder_battery.sh` (series 4/10
+→ 7/10 → 6/11 → 5/11 → 9/11 → 6/11 → 3/12-infra → 6/12; run-to-run
+variance ≈ 5 points on whether turn 1's build lands). Standing smaller
+follow-ups: #110, the injector's scope-blind binding, #106, the serve
+trace's ~280-char node-response truncation (blocks post-hoc held-round
+diagnosis), and the glob-result verbatim wire capture (the wire log is
+shape-only — a capture needs a body-dumping probe, not
+LLM_ORC_SERVE_WIRE_LOG). #107 is fixed on branch
+`worktree-fix-107-content-parts` (endpoint-boundary normalizer — the
+422 fired at pydantic before the caller could crash). Ops notes: the
+harness reaps tracked background serves/batteries mid-long-run — start
+them detached (nohup + disown) with a Monitor tail; give the rig
+cooling headroom between batteries.
 
 Key empirical facts the next work builds on:
 

--- a/src/llm_orc/web/api/v1_chat_completions.py
+++ b/src/llm_orc/web/api/v1_chat_completions.py
@@ -35,7 +35,7 @@ from typing import Any, Protocol
 
 from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from llm_orc.core.session.registry import SessionRegistry
 from llm_orc.web.api.sse_format import OpenAiSseFormatter, encode_tool_call_for_message
@@ -153,18 +153,43 @@ class _ChatCompletionMessage(BaseModel):
     tool_call_id: str | None = None
     tool_calls: list[dict[str, Any]] | None = None
 
+    @field_validator("content")
+    @classmethod
+    def _parts_carry_text(
+        cls, value: str | list[dict[str, Any]] | None
+    ) -> str | list[dict[str, Any]] | None:
+        """Reject parts lists this text-only backend cannot route honestly.
+
+        Every part needs a string ``type`` (wire-invalid otherwise — a
+        typeless text part would silently drop from the join); a text part
+        needs a string ``text`` (str() coercion would leak Python reprs
+        into the transcript and session hash); and the join must be
+        non-blank — empty user content silently slides the turn boundary
+        back to a stale task (PR #113 review blocker).
+        """
+        if not isinstance(value, list):
+            return value
+        for part in value:
+            if not isinstance(part.get("type"), str):
+                raise ValueError("content part requires a string 'type'")
+            if part["type"] == "text" and not isinstance(part.get("text"), str):
+                raise ValueError("text content part requires a string 'text'")
+        if not _joined_text_parts(value).strip():
+            raise ValueError("content parts carry no text to route on")
+        return value
+
+
+def _joined_text_parts(parts: list[dict[str, Any]]) -> str:
+    """Text parts joined into plain text; non-text parts (``image_url``, …)
+    carry nothing the serving layer can route on and are dropped."""
+    return "\n".join(part["text"] for part in parts if part["type"] == "text")
+
 
 def _text_content(content: str | list[dict[str, Any]] | None) -> str | None:
-    """Join list-shaped (content-parts) message content into plain text.
-
-    Non-text parts (``image_url``, …) carry nothing the serving layer can
-    route on and are dropped from the join.
-    """
+    """Normalize validated message content to OpenAI's plain-string shape."""
     if not isinstance(content, list):
         return content
-    return "\n".join(
-        str(part.get("text", "")) for part in content if part.get("type") == "text"
-    )
+    return _joined_text_parts(content)
 
 
 class _ChatCompletionsRequest(BaseModel):

--- a/src/llm_orc/web/api/v1_chat_completions.py
+++ b/src/llm_orc/web/api/v1_chat_completions.py
@@ -35,7 +35,7 @@ from typing import Any, Protocol
 
 from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from llm_orc.core.session.registry import SessionRegistry
 from llm_orc.web.api.sse_format import OpenAiSseFormatter, encode_tool_call_for_message
@@ -155,17 +155,15 @@ class _ChatCompletionMessage(BaseModel):
 
     @field_validator("content")
     @classmethod
-    def _parts_carry_text(
+    def _parts_are_well_shaped(
         cls, value: str | list[dict[str, Any]] | None
     ) -> str | list[dict[str, Any]] | None:
-        """Reject parts lists this text-only backend cannot route honestly.
+        """Reject malformed content parts on any role.
 
         Every part needs a string ``type`` (wire-invalid otherwise — a
         typeless text part would silently drop from the join); a text part
         needs a string ``text`` (str() coercion would leak Python reprs
-        into the transcript and session hash); and the join must be
-        non-blank — empty user content silently slides the turn boundary
-        back to a stale task (PR #113 review blocker).
+        into the transcript and session hash).
         """
         if not isinstance(value, list):
             return value
@@ -174,14 +172,29 @@ class _ChatCompletionMessage(BaseModel):
                 raise ValueError("content part requires a string 'type'")
             if part["type"] == "text" and not isinstance(part.get("text"), str):
                 raise ValueError("text content part requires a string 'text'")
-        if not _joined_text_parts(value).strip():
-            raise ValueError("content parts carry no text to route on")
         return value
+
+    @model_validator(mode="after")
+    def _user_parts_carry_text(self) -> _ChatCompletionMessage:
+        """Reject a USER parts message whose text joins to blank.
+
+        Empty user content silently slides the turn boundary back to a
+        stale task (PR #113 review blocker). Scoped to user messages:
+        only they feed ``_task_from``/``_latest_user_index``, and an
+        empty tool result as parts is wire-legal (silent-success
+        commands) with an honest empty-string render.
+        """
+        if self.role == "user" and isinstance(self.content, list):
+            if not _joined_text_parts(self.content).strip():
+                raise ValueError("user content parts carry no text to route on")
+        return self
 
 
 def _joined_text_parts(parts: list[dict[str, Any]]) -> str:
-    """Text parts joined into plain text; non-text parts (``image_url``, …)
-    carry nothing the serving layer can route on and are dropped."""
+    """VALIDATED text parts joined into plain text; non-text parts
+    (``image_url``, …) carry nothing the serving layer can route on and
+    are dropped. Callers must not hand this raw wire dicts — the bare
+    indexing assumes ``_parts_are_well_shaped`` ran."""
     return "\n".join(part["text"] for part in parts if part["type"] == "text")
 
 

--- a/src/llm_orc/web/api/v1_chat_completions.py
+++ b/src/llm_orc/web/api/v1_chat_completions.py
@@ -86,7 +86,7 @@ def _log_wire_shape(request: _ChatCompletionsRequest) -> None:
     rows = []
     digest = hashlib.sha256()
     for message in request.messages:
-        content = message.content or ""
+        content = _text_content(message.content) or ""
         digest.update(f"{message.role}\x00{content}\x00".encode())
         rows.append(
             {
@@ -142,13 +142,29 @@ class _ChatCompletionMessage(BaseModel):
     result as ``content``. Both are optional so the common case
     (``role: user``, ``role: system``) parses without change.
     ``content`` is nullable because OpenAI accepts ``content: null`` on
-    an assistant message whose turn carried only tool calls.
+    an assistant message whose turn carried only tool calls, and may be
+    list-shaped (content parts) — normalized to plain text at this
+    boundary by :func:`_text_content` (issue #107) so the serving layer
+    stays str-only downstream.
     """
 
     role: str
-    content: str | None = None
+    content: str | list[dict[str, Any]] | None = None
     tool_call_id: str | None = None
     tool_calls: list[dict[str, Any]] | None = None
+
+
+def _text_content(content: str | list[dict[str, Any]] | None) -> str | None:
+    """Join list-shaped (content-parts) message content into plain text.
+
+    Non-text parts (``image_url``, …) carry nothing the serving layer can
+    route on and are dropped from the join.
+    """
+    if not isinstance(content, list):
+        return content
+    return "\n".join(
+        str(part.get("text", "")) for part in content if part.get("type") == "text"
+    )
 
 
 class _ChatCompletionsRequest(BaseModel):
@@ -188,7 +204,7 @@ def _resolve_context(request: _ChatCompletionsRequest) -> SessionContext:
     messages = [
         ChatMessage(
             role=message.role,
-            content=message.content,
+            content=_text_content(message.content),
             tool_call_id=message.tool_call_id,
             tool_calls=tuple(message.tool_calls) if message.tool_calls else (),
         )

--- a/tests/unit/web/test_api_v1_chat_completions.py
+++ b/tests/unit/web/test_api_v1_chat_completions.py
@@ -264,6 +264,75 @@ class TestChatCompletionsRequestParsing:
         assert response.status_code == 200
         assert stub.contexts[0].messages[-1].content == "explain\ntodo.py"
 
+    def test_textless_content_parts_message_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A parts message with no text (image-only, or text joining to
+        whitespace) would normalize to empty content, and empty user
+        content silently slides the turn boundary back to a stale task
+        (PR #113 review blocker). Textless parts 422 honestly instead."""
+        client, _, _ = _build_client(monkeypatch)
+
+        for parts in (
+            [{"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}}],
+            [{"type": "text", "text": "   "}],
+            [],
+        ):
+            response = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "primary",
+                    "messages": [
+                        {"role": "user", "content": "build todo.py"},
+                        {"role": "assistant", "content": "done"},
+                        {"role": "user", "content": parts},
+                    ],
+                },
+            )
+
+            assert response.status_code == 422, parts
+
+    def test_text_part_with_non_string_text_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OpenAI 422s a text part whose ``text`` is not a string; without
+        the check, str() coercion leaks Python reprs ('None', "{'a': 1}")
+        into the transcript and session hash (PR #113 review)."""
+        client, _, _ = _build_client(monkeypatch)
+
+        for bad_text in (None, 123, {"a": 1}):
+            response = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "primary",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [{"type": "text", "text": bad_text}],
+                        }
+                    ],
+                },
+            )
+
+            assert response.status_code == 422, bad_text
+
+    def test_content_part_missing_type_key_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A part with no ``type`` is invalid on the wire; dropping it from
+        the join silently discards the user's text (PR #113 review)."""
+        client, _, _ = _build_client(monkeypatch)
+
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "primary",
+                "messages": [{"role": "user", "content": [{"text": "hello"}]}],
+            },
+        )
+
+        assert response.status_code == 422
+
 
 class TestRequestRouting:
     """``POST /v1/chat/completions`` routes every request through the serving caller.

--- a/tests/unit/web/test_api_v1_chat_completions.py
+++ b/tests/unit/web/test_api_v1_chat_completions.py
@@ -235,6 +235,35 @@ class TestChatCompletionsRequestParsing:
 
         assert response.status_code == 200
 
+    def test_content_parts_message_normalizes_to_joined_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """List-shaped (content-parts) message content is legal on the
+        OpenAI wire (issue #107): the request parses and the caller sees
+        the text parts joined into one plain string, so every downstream
+        content read stays str-only."""
+        stub = _StubCaller()
+        client, _, _ = _build_client(monkeypatch, terminal=stub)
+
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "primary",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "explain"},
+                            {"type": "text", "text": "todo.py"},
+                        ],
+                    }
+                ],
+            },
+        )
+
+        assert response.status_code == 200
+        assert stub.contexts[0].messages[-1].content == "explain\ntodo.py"
+
 
 class TestRequestRouting:
     """``POST /v1/chat/completions`` routes every request through the serving caller.

--- a/tests/unit/web/test_api_v1_chat_completions.py
+++ b/tests/unit/web/test_api_v1_chat_completions.py
@@ -264,6 +264,49 @@ class TestChatCompletionsRequestParsing:
         assert response.status_code == 200
         assert stub.contexts[0].messages[-1].content == "explain\ntodo.py"
 
+    def test_textless_parts_tool_result_is_accepted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty tool result as parts is wire-legal (silent-success
+        commands: ruff clean, touch) and its empty-STRING twin already
+        renders honestly; only USER messages feed the turn boundary, so
+        the blank-join rejection must not fire on other roles (PR #113
+        re-review finding)."""
+        stub = _StubCaller()
+        client, _, _ = _build_client(monkeypatch, terminal=stub)
+
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "primary",
+                "messages": [
+                    {"role": "user", "content": "lint the repo"},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "c1",
+                                "type": "function",
+                                "function": {
+                                    "name": "bash",
+                                    "arguments": '{"command": "ruff check ."}',
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "c1",
+                        "content": [{"type": "text", "text": ""}],
+                    },
+                ],
+            },
+        )
+
+        assert response.status_code == 200
+        assert stub.contexts[0].messages[-1].content == ""
+
     def test_textless_content_parts_message_is_rejected(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/web/test_serving_ensemble_endpoint.py
+++ b/tests/unit/web/test_serving_ensemble_endpoint.py
@@ -414,6 +414,43 @@ def test_wire_log_records_message_shape_when_enabled(
     assert "hello" not in wire_log.read_text()
 
 
+def test_wire_log_normalizes_parts_content_to_text_length(
+    serving_project: Path,
+    serving_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A parts-shaped message logs its joined TEXT length (not the part
+    count) and hashes identically to its plain-string twin — the wire-log
+    call site shares the #107 boundary normalizer, and a revert to raw
+    ``message.content`` would silently diverge (PR #113 review note)."""
+    wire_log = tmp_path / "wire.jsonl"
+    monkeypatch.setenv("LLM_ORC_SERVE_WIRE_LOG", str(wire_log))
+
+    task = "explain what\nfoo.py does"
+    for content in (
+        task,
+        [
+            {"type": "text", "text": "explain what"},
+            {"type": "text", "text": "foo.py does"},
+        ],
+    ):
+        resp = serving_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "ensemble-agent",
+                "messages": [{"role": "user", "content": content}],
+                "tools": [_WRITE_TOOL],
+            },
+        )
+        assert resp.status_code == 200
+
+    rows = [json.loads(line) for line in wire_log.read_text().strip().splitlines()]
+    string_row, parts_row = rows[-2]["messages"][0], rows[-1]["messages"][0]
+    assert parts_row["content_len"] == len(task)  # text length, not part count
+    assert parts_row["prefix_hash"] == string_row["prefix_hash"]  # true twins
+
+
 def test_invisible_named_file_turn_emits_a_read_tool_call(
     serving_client: TestClient,
 ) -> None:


### PR DESCRIPTION
## What

Closes #107. A list-shaped (content-parts) message — legal on the OpenAI wire — never reached the caller's str-only content reads: the request model typed `content: str | None`, so parts-shaped requests died 422 at pydantic validation. The issue's sketched fix (a normalizer inside `serving_ensemble_caller`) would therefore never see the message; content enters through exactly one boundary. Fix: widen `_ChatCompletionMessage.content` to accept parts and normalize at that boundary — `_text_content` joins text parts to plain text, so `ChatMessage.content` stays `str | None` everywhere downstream, including the wire-shape log's hash chain. Malformed parts (typeless, non-string text) 422 on every role; a USER parts message whose text joins to blank 422s (empty user content silently slides the turn boundary to a stale task); an empty parts tool result stays accepted (silent-success commands render honestly).

Also carries the fresh-rig battery record: trajectory row (6/12 clean, 12.5 min, zero timeouts — the series' first two dishonest misses noted) and the handoff pointer now aimed at the fix-execution rung with its two mapped blockers.

## Review record

Independent adversarial reviewer (fresh context), three rounds:
- **Round 1: REQUEST-CHANGES.** Blocker confirmed by probe: an image-only latest user message (legal wire, 422'd before this PR) joined to empty text and the empty-content skip in `_task_from`/`_latest_user_index` slid the turn boundary to a stale task — the serve would silently re-execute a previous build. Two should-fixes in the same normalizer: `str()` coercion leaking Python reprs ('None', "{'a': 1}") into the transcript and session hash; typeless parts silently discarding user text. Note: the wire-log call site's normalization was revert-able without failing the suite. All fixed with the reviewer's inputs pinned as tests.
- **Round 2: APPROVE with a should-fix taken.** The blank-join rule was role-blind and over-rejected wire-legal empty parts tool results (silent-success commands). Fixed: shape rules stay universal, the blank rule scopes to `role == "user"` (the only role feeding the turn boundary).
- **Round 3: APPROVE, no open findings.** Original blocker still closed; mixed image+text 200s with exact text; shape 422s on all roles; validator ordering (field before model) confirmed to keep the bare-index join safe.

Clean probes across rounds: header-spoofing via parts join (defanged, no column-0 header reachable), wire-log twin hashing (parts and string twins hash identically at both call sites), session-identity stability across content shapes, parts-shaped tool results rendering correct fenced blocks, no other raw-request readers, 10k-part scale, and wrong-implementation defeat checks on the new tests.

**Standing observation (pre-existing, out of scope):** a whitespace-only plain-STRING latest user message still 200s and slides the turn boundary — the string-shaped twin of the round-1 blocker, present on main before this PR. Worth a follow-up if turn-boundary honesty gets further hardening.

## Evidence

- TDD throughout: every behavior watched failing first (422-vs-200 both directions).
- Live (worktree serve on a spare port): a parts-shaped request returns 200 with a well-formed completion; pre-fix this 422'd.
- Full suite green: 2807 passed, 91.77% coverage; strict hooks (mypy/ruff/format/complexipy/vulture).
