### PR TITLE
Chained fix-execution: write → run → verdict inside one fix turn

### DIFF
--- a/.llm-orc/scripts/agentic_serving/classify.py
+++ b/.llm-orc/scripts/agentic_serving/classify.py
@@ -78,6 +78,13 @@ _BUILD_RE = re.compile(
 _EXISTING_RE = re.compile(
     r"\b(fix|update|modify|refactor|edit|change|existing)\b", re.IGNORECASE
 )
+# Chained fix-execution trigger: the task must be LED by a fix imperative —
+# mid-sentence "existing"/"change" are ordinary build prose (PR #115
+# review). Mirrors the caller's _FIX_CHAIN_RE; a regression test pins
+# pattern and flags equal.
+_FIX_VERB_RE = re.compile(
+    r"^\s*(?:fix|update|modify|refactor|edit|change)\b", re.IGNORECASE
+)
 # Context-block headers (the caller's render grammar). Visible = untruncated
 # wrote block or successful read block; attempted = any read header. The
 # optional variant group keeps a "(truncated)" suffix out of the path.
@@ -520,7 +527,7 @@ def main() -> None:
     # structural (the caller derives it from post-boundary write tool_calls,
     # never from context text — forged [wrote] lines cannot set it).
     wrote_path = str(turn.get("wrote_path", ""))
-    fix_chain = bool(wrote_path) and bool(_EXISTING_RE.search(task))
+    fix_chain = bool(wrote_path) and bool(_FIX_VERB_RE.match(task))
 
     needs_glob = glob_file = glob_failed = ""
     needs_files: list[str] = []

--- a/.llm-orc/scripts/agentic_serving/classify.py
+++ b/.llm-orc/scripts/agentic_serving/classify.py
@@ -376,8 +376,7 @@ def _discovery(
             return (
                 "",
                 "",
-                f"multiple visible files match '{stem}': {listed}"
-                " — please name one",
+                f"multiple visible files match '{stem}': {listed} — please name one",
             )
         return stem, "", ""
     if len(candidates) == 1:
@@ -428,6 +427,7 @@ def _route(
     *,
     is_explain: bool,
     run_signal: bool,
+    fix_chain: bool,
     has_run_block: bool,
     needs_glob: str,
     glob_failed: str,
@@ -443,6 +443,16 @@ def _route(
     interrogative or marker-led turns), so "run the tests and tell me what
     failed" delegates the run instead of narrating one.
     """
+    if fix_chain and has_run_block:
+        # fix-execution verdict leg: the chained run came back — parse it.
+        return "run-verdict", "run_verdict", False, False
+    if fix_chain:
+        # fix-execution run leg: this turn's fix already shipped its write
+        # (wrote_path is structural, from the caller's post-boundary
+        # tool_calls); delegate ONE closed-template run to verify it
+        # client-side. Never re-enters the build — the branches below are
+        # unreachable while fix_chain holds.
+        return "need-run", "need_run", False, False
     if run_signal and has_run_block:
         # issue #83 run half: the client ran the command — the deliverable
         # is the deterministic verdict, one run round per turn.
@@ -505,10 +515,17 @@ def main() -> None:
     conversation_raw = str(turn.get("context", ""))
     has_run_block = bool(_RAN_HEADER_RE.search(conversation_raw))
 
+    # Chained fix-execution: a fix-intent turn whose gated build already
+    # shipped its write THIS turn chains into the run seam. wrote_path is
+    # structural (the caller derives it from post-boundary write tool_calls,
+    # never from context text — forged [wrote] lines cannot set it).
+    wrote_path = str(turn.get("wrote_path", ""))
+    fix_chain = bool(wrote_path) and bool(_EXISTING_RE.search(task))
+
     needs_glob = glob_file = glob_failed = ""
     needs_files: list[str] = []
     read_failed = ""
-    if not is_explain and not run_signal:
+    if not is_explain and not run_signal and not fix_chain:
         needs_glob, glob_file, glob_failed = _discovery(
             task, conversation_raw, tests_primary, has_build_signal
         )
@@ -522,11 +539,13 @@ def main() -> None:
         needs_files, read_failed = _files_to_request(
             task, conversation_raw, tests_primary, has_build_signal, glob_file
         )
-    needs_run = _run_test_command(task) if run_signal and not has_run_block else ""
+    wants_run = run_signal or fix_chain
+    needs_run = _run_test_command(task) if wants_run and not has_run_block else ""
 
     target, kind, build, needs_decider = _route(
         is_explain=is_explain,
         run_signal=run_signal,
+        fix_chain=fix_chain,
         has_run_block=has_run_block,
         needs_glob=needs_glob,
         glob_failed=glob_failed,

--- a/.llm-orc/scripts/agentic_serving/run_verdict.py
+++ b/.llm-orc/scripts/agentic_serving/run_verdict.py
@@ -91,6 +91,9 @@ def _verdict(command: str, variant: str, detail: str, body: str) -> str:
     if variant == "failed":
         reason = detail or "empty run result"
         return f"The test run could not execute: {reason}"
+    if "rejected permission" in body.lower():
+        # the client declined the command — nothing ran (PR #115 review)
+        return f"The test run was not permitted by the client (`{command}`)."
     summary = _summary_line(body)
     if not summary:
         tail = "\n".join(body.splitlines()[-_TAIL_LINES:])

--- a/.llm-orc/scripts/agentic_serving/run_verdict.py
+++ b/.llm-orc/scripts/agentic_serving/run_verdict.py
@@ -91,11 +91,13 @@ def _verdict(command: str, variant: str, detail: str, body: str) -> str:
     if variant == "failed":
         reason = detail or "empty run result"
         return f"The test run could not execute: {reason}"
-    if "rejected permission" in body.lower():
-        # the client declined the command — nothing ran (PR #115 review)
-        return f"The test run was not permitted by the client (`{command}`)."
     summary = _summary_line(body)
     if not summary:
+        # summary-less bodies only — the duration-anchored summary line
+        # stays authoritative, so phrase-shaped stdout from a REAL run can
+        # never shadow the result (PR #115 review, both rounds)
+        if "rejected permission" in body.lower():
+            return f"The test run was not permitted by the client (`{command}`)."
         tail = "\n".join(body.splitlines()[-_TAIL_LINES:])
         return (
             f"Ran `{command}`, but the output carried no pytest summary. "

--- a/benchmarks/agentic_serving/ladder_battery.sh
+++ b/benchmarks/agentic_serving/ladder_battery.sh
@@ -19,6 +19,15 @@
 #
 #   def mean(values): sum/len, raise-on-empty ValueError
 #
+# and buggy.py + test_buggy.py (turn 13's fix-execution rung — seeded RED:
+# the module lacks the guard its test expects, so the client suite fails
+# until the fix lands):
+#
+#   buggy.py:      def scale(values, factor): [v * factor for v in values]
+#                  (no None/empty guard)
+#   test_buggy.py: test_scale_basic (passes); test_scale_empty_raises —
+#                  pytest.raises(ValueError, match="no values") on scale([], 2)
+#
 # Scoring (strict, per the trajectory table): a turn passes only when its
 # deliverable ships and is correct; honest rejects/refusals are misses and
 # noted as honest. Expected-behavior exceptions: turn 9 PASSES on an honest
@@ -27,7 +36,13 @@
 # verdict matches the client-side result — the honest verdict IS the
 # deliverable, whatever color the suite is; turn 12 (the #83 discovery
 # rung) PASSES when the serve globs the unnamed module, reads the match,
-# and ships tests for it (test_metrics.py, green client-side).
+# and ships tests for it (test_metrics.py, green client-side). Turn 13
+# (the fix-execution rung) PASSES only when the fix LANDS: the chain
+# (write -> delegated pytest -> verdict) fires and the SEEDED red test
+# (test_buggy.py) goes green client-side — scored on the seeded target
+# alone so earlier turns' residue cannot cascade into this rung. An
+# honest red verdict on an unfixed bug is an honest miss; a verdict that
+# contradicts client ground truth is a dishonest one.
 set -u
 REPO=${LADDER_REPO:?set LADDER_REPO to a seeded scratch repo}
 OUT=${LADDER_OUT:?set LADDER_OUT to an output dir}
@@ -47,6 +62,7 @@ PROMPTS=(
   "what did the first thing I asked you to build do?"
   "run the tests"
   "write tests for the metrics module"
+  "fix the bug in buggy.py"
 )
 i=0
 for p in "${PROMPTS[@]}"; do

--- a/docs/plans/2026-07-10-fix-execution-design.md
+++ b/docs/plans/2026-07-10-fix-execution-design.md
@@ -28,13 +28,17 @@ else (read→build, run→verdict).
 
 ## Decisions
 
-- **Chain trigger (rung 1, vary one thing): fix-intent turns only.**
-  A turn matching classify's existing `_EXISTING_RE` fix-verb class
-  (classify.py:78) whose gated build ACCEPTED chains into one delegated
-  run. Ordinary "write X" build turns keep today's terminal ack — no
-  behavior change outside the fix class. Widening the trigger (all gated
-  builds; presence of client-side tests) is a later rung, decided on
-  ladder evidence.
+- **Chain trigger (rung 1, vary one thing): turns LED by a fix
+  imperative.** A task matching `_FIX_VERB_RE`
+  (`^\s*(?:fix|update|modify|refactor|edit|change)\b`) whose gated build
+  ACCEPTED chains into one delegated run. Anchored to the task start
+  after PR #115 review: mid-sentence "existing"/"change" are ordinary
+  build prose ("write add.py so the existing tests pass" must not
+  chain), and `_EXISTING_RE`'s read-first role is untouched. Ordinary
+  "write X" build turns keep today's terminal ack — no behavior change
+  outside the fix-led class. Widening the trigger (all gated builds;
+  presence of client-side tests) is a later rung, decided on ladder
+  evidence.
 - **The write continuation resumes; classify decides what happens.**
   `_resumes_turn` admits write-shaped results. On resume the whole
   pipeline re-runs statelessly from the wire (the mechanism read→build
@@ -89,9 +93,13 @@ else (read→build, run→verdict).
   on the run/verdict passes (the new guard, symmetric with
   `has_run_block` flipping need-run → run-verdict today), and the run
   seam's one-round rule is untouched.
-- A failed client-side write (tool result carries an error) must NOT
-  chain: ack honestly, terminal. Detection is deterministic (the write
-  result body), mirrors read-failure refusals.
+- A failed client-side write must NOT chain: ack honestly ("Write
+  failed for X."), terminal. Detection mirrors the read path's
+  lowercased prefixes ("error", "file not found") plus the client
+  permission-denial phrase and empty/absent result bodies — all
+  fail-closed to the honest ack (PR #115 review blocker: the original
+  case-sensitive match let denied writes chain, and the verdict framed
+  an unapplied fix as verified).
 - Forged `[wrote ...]` lines in user prose must not trigger runs — the
   fenced block grammar (v0.18.9) already anchors real blocks; the
   `has_wrote_block` selector reads the same post-boundary tool_call

--- a/docs/plans/2026-07-10-fix-execution-design.md
+++ b/docs/plans/2026-07-10-fix-execution-design.md
@@ -1,10 +1,13 @@
 # Chained fix-execution: write → run → verdict in one turn
 
-**Status:** Draft design, 2026-07-10 (post fresh-rig battery). The rung the
-roadmap names as pure composition of shipped seams. No new machinery is
-proposed here — two structural changes and one classify signal. Seam map
-evidence: this session's exploration of the caller and classify (file:line
-references below are v0.18.11).
+**Status:** Implemented 2026-07-10, same session as the design (branch
+worktree-fix-execution). Live-validated against real OpenCode: the full
+chain fired (need-files → code-seat → need-run → run-verdict) with an
+honest red verdict on a fix the seat failed to apply — the exact
+server-gate blind spot this rung closes — and a plain build turn stayed
+terminal. Rung-1 scope shipped as designed; no deviations from this text.
+Seam map evidence: this session's exploration of the caller and classify
+(file:line references below are v0.18.11).
 
 ## Problem
 

--- a/docs/plans/2026-07-10-fix-execution-design.md
+++ b/docs/plans/2026-07-10-fix-execution-design.md
@@ -1,0 +1,129 @@
+# Chained fix-execution: write → run → verdict in one turn
+
+**Status:** Draft design, 2026-07-10 (post fresh-rig battery). The rung the
+roadmap names as pure composition of shipped seams. No new machinery is
+proposed here — two structural changes and one classify signal. Seam map
+evidence: this session's exploration of the caller and classify (file:line
+references below are v0.18.11).
+
+## Problem
+
+A fix/build turn ships its write and terminates. The artifact was verified
+in the serve's sandbox against serve-authored tests — never against the
+client repo's real suite in the client's real environment. The run seam
+(v0.18.8) closed that gap for explicit "run the tests" turns; fix turns
+can't reach it. Today's battery showed the cost concretely: a fix turn's
+deliverable is a one-shot bet, and per-decision success doesn't compose to
+per-session success.
+
+The single structural blocker (mapped 2026-07-10): a write continuation is
+terminal. `_resumes_turn` (serving_ensemble_caller.py:578) admits only
+read/run/glob-shaped tool results; a write result gets a deterministic
+"Wrote X." ack (`_tool_result_ack`:589) and the turn ends. Multi-hop
+chaining through stateless classify re-routing already works everywhere
+else (read→build, run→verdict).
+
+## Decisions
+
+- **Chain trigger (rung 1, vary one thing): fix-intent turns only.**
+  A turn matching classify's existing `_EXISTING_RE` fix-verb class
+  (classify.py:78) whose gated build ACCEPTED chains into one delegated
+  run. Ordinary "write X" build turns keep today's terminal ack — no
+  behavior change outside the fix class. Widening the trigger (all gated
+  builds; presence of client-side tests) is a later rung, decided on
+  ladder evidence.
+- **The write continuation resumes; classify decides what happens.**
+  `_resumes_turn` admits write-shaped results. On resume the whole
+  pipeline re-runs statelessly from the wire (the mechanism read→build
+  already uses). A new deterministic classify signal — `has_wrote_block`
+  (this-turn `[wrote <path>]` present, selected from post-boundary
+  messages exactly as `_run_blocks`/`_glob_blocks` are,
+  serving_ensemble_caller.py:475/511) — routes:
+  - fix-intent + wrote-block + no run block → `need-run` (existing shape)
+  - run block present → `run-verdict` (existing shape, classify.py:446)
+  - anything else (non-fix turn, or guards below) → terminal "Wrote X."
+    ack, exactly today's behavior.
+- **The run-verb suppression stays.** classify suppresses `run_signal`
+  when build/fix verbs are present (classify.py:495) so a fix turn can
+  never route to run on its FIRST pass. Unchanged. The chain's run leg is
+  triggered by the wrote-block signal on the resume, not by the verb —
+  the suppression and the chain compose instead of conflicting.
+- **The run is the existing closed template.** `pytest -q` (plus named
+  `test_` files when the turn names them) — the same deterministic
+  builder and verdict parser as explicit run turns. Zero model calls in
+  the chain's second and third legs.
+- **Red verdict = honest report, no within-turn re-fix (rung 1).**
+  "Wrote todo.py. Ran `pytest -q`: 2 failed, 5 passed." + failure lines.
+  The bounded re-fix loop (feed the client-side failure report back as
+  retry carry, like the #100 held round) is the natural rung 2 — it is
+  where the compounding-reliability payoff lives, but it multiplies
+  rounds and belongs behind a measured rung-1 baseline. Held open, not
+  decided here.
+- **No new shape, no new catalog entry.** The chain reuses `need-run` and
+  `run-verdict` as-is; the #106 two-homes trap is not fed. The only
+  touched surfaces are `_resumes_turn`/`_tool_result_ack`, classify, and
+  (possibly) emit's finish-prose composition so the verdict message names
+  the written file.
+
+## Turn flow (three passes, all stateless from the wire)
+
+1. **Fix pass (today's behavior):** "fix the divide bug in calc.py" →
+   read preamble if calc.py is invisible (existing need-files seam) →
+   gated build → emit write tool_call. Reject path unchanged (honest
+   "Another round needed", no chain — nothing shipped, nothing to run).
+2. **Run pass (new):** client applies the write, POSTs the appended wire
+   ending in the write tool result → `_resumes_turn` admits it →
+   classify: fix-intent + `has_wrote_block` + no run block → `need-run`
+   → ONE bash tool_call (`pytest -q`).
+3. **Verdict pass (existing):** run result arrives → classify sees the
+   `[ran]` block → `run-verdict` parses pytest's summary → finish prose
+   reporting write + verdict honestly, green or red.
+
+## Bounds and error handling
+
+- One write, one run, one verdict per turn. Loop-safety is the existing
+  per-seam idempotency: `has_wrote_block` never re-dispatches the build
+  on the run/verdict passes (the new guard, symmetric with
+  `has_run_block` flipping need-run → run-verdict today), and the run
+  seam's one-round rule is untouched.
+- A failed client-side write (tool result carries an error) must NOT
+  chain: ack honestly, terminal. Detection is deterministic (the write
+  result body), mirrors read-failure refusals.
+- Forged `[wrote ...]` lines in user prose must not trigger runs — the
+  fenced block grammar (v0.18.9) already anchors real blocks; the
+  `has_wrote_block` selector reads the same post-boundary tool_call
+  structure `_run_blocks` does, not text. Pin with a spoof probe anyway.
+- Non-OpenCode clients that never re-POST after a write see exactly
+  today's behavior (the chain only exists on the continuation).
+
+## Testing and validation
+
+- Hermetic e2e through the real engine: fix turn → write resume → run
+  tool_call emitted → verdict prose; reject-path and non-fix-build
+  regressions (terminal ack unchanged); write-failure no-chain; spoof
+  probe (forged wrote block in user text).
+- Live real-OpenCode at the earliest runnable point (the WP-A lesson):
+  seed a repo with a failing test + buggy source; drive "fix the failing
+  test" end to end; verify green verdict matches client ground truth,
+  and a deliberately unfixable case reports red honestly.
+- Ladder: add the fix-execution rung as a new battery turn against a
+  seeded red repo. Exit gate: rung green on a clean-rig run with zero
+  regressions on the existing 12.
+- Trace: assert the chain is diagnosable from the turn trace (three
+  passes visible) — the ~280-char node-response truncation found today
+  makes post-hoc gate diagnosis impossible and should be fixed or
+  bounded before this rung's live validation leans on the trace.
+
+## Named forward directions (not built here)
+
+- **Within-turn re-fix on red** (rung 2): bounded retry carrying the
+  client-side failure report, composing with the #100 held-round
+  machinery. The reliability-compounding rung.
+- **Cross-turn repair** (sibling rung, first clean evidence in today's
+  battery): "target file was never successfully built but the
+  conversation describes what it should contain" is a deterministic,
+  detectable condition; turn 2 of the ladder could rebuild todo.py fresh
+  instead of cascading. Design separately; do not fold into this rung.
+- **Runner generalization**: cargo test for the plexus half of the
+  meta-task rung — the command builder and verdict parser are the only
+  pytest-aware seams (unchanged claim from the run-half design).

--- a/docs/serving-roadmap.md
+++ b/docs/serving-roadmap.md
@@ -38,6 +38,7 @@ model as the backend. Trajectory so far:
 | 2026-07-10 (repairs round 2, post-review-fix) | 11-turn recorded ladder (resumed at turn 6 after a harness process reap; detached runner thereafter) | **6/11** | Three wrong-accept vectors from the adversarial review closed pre-merge (substring expectation match, anywhere-in-body removal wrap, lambda-param binding blindness) — the fixes are deliberately conservative and refuse ambiguous rewrites, trading conversions for gate honesty. 3 honest build rejects + cascade + #82. Named follow-up with evidence: tighten the negation refusal to expectation-adjacent tokens ("Expected TypeError not raised" currently refuses) |
 | 2026-07-10 (#83 discovery) | 12-turn recorded ladder (discovery rung added) | **3/12, infra-degraded** | The rung this battery validates PASSED clean: turn 12 globbed the unnamed metrics module, read the match, shipped test_metrics.py (green client-side). Run rung honest ("no tests ran" — accurate at that moment), phantom refusal honest. The rest is rig exhaustion after six batteries in one day: four turns timed out with EMPTY output (not rejects — the request died client- or model-side), cascading the todo chain. Zero dishonest outcomes. NOT comparable to the series; fresh-rig rerun is the next session's first act. Separate live probes (same code): 1-match chain, 0-match refusal, 2-match refusal all green |
 | 2026-07-10 (fresh-rig rerun, v0.18.11) | 12-turn recorded ladder, clean infra (12 turns in 12.5 min, zero timeouts) | **6/12** | All shipped rungs green: memory (turn 5), storage build (6), read→tests (8, 4 green client-side), phantom refusal (9), run delegation (11, verdict matched ground truth), discovery chain (12, glob→read→test_metrics.py green). Misses: turn 1 round-1 reject (code referenced an undefined `todo` name) cascading through 2/3/4/7, and turn 10 deep recall. **Two misses were NOT honest** — a first for the recorded series: turn 3 shipped hedged speculation about the never-built todo.py instead of saying so (grounded-explain gap), and turn 10 confidently named calc-tests as "the first thing built" (wrong under both readings; #82 evidence). Structural readings: turn-1 build success gates 5 of 12 turns, so run-to-run variance ≈ 5 points on one seat sample; the serve trace truncates node responses (~280 chars), leaving the held-round question undiagnosable post-hoc; the wire log is shape-only, so the verbatim glob capture remains outstanding |
+| 2026-07-10 (fix-execution rung) | 13-turn recorded ladder (fix rung added: seeded-red buggy.py; one 600s timeout) | **6/13** | THE NEW RUNG'S MECHANISM PROVED IN-BATTERY: turn 13 chained read → write → delegated `pytest -q` → verdict, and the verdict was honest and precise — the seat's fix added the guard with its own exception message ("scale of empty sequence") where the seeded test expects "no values", and the verdict surfaced the exact expected-vs-actual regex mismatch. Honest miss by the strict rule (the seeded test stayed red), and the failure report is precisely the carry a rung-2 re-fix loop needs — plus a cheap rung-1.5: read the visible test_<stem>.py when fixing <stem>.py so the fix sees the expected behavior. Also observed: turn 8's "tests for existing calc.py" triggered the chain via the "existing" verb after its tests-seat write (honest whole-suite report; not designed-for, informative in practice). Other passes: 5, 6, 8, 9, 11 (verdict matched ground truth), 12 (discovery chain green). Misses: turn 1 honest reject cascading 3/4/7, turn 2 a 600s client timeout (the seat's 720s two-round budget exceeds the battery cap — latency class, not a reject), turn 10 wrong recall (named storage.py, the first successful build, as "the first thing asked" — the todo ask came first; #82) |
 
 The Cycle-7 benchmark harness (`research/agentic-serving-corpus` branch,
 `benchmark-runs/`) is the automation to revive for a standing
@@ -104,40 +105,43 @@ deterministic accept gate (per-test-isolated executor + static adequacy
 into the shipped artifact). All-local (qwen3:8b) by default; operator
 seat overrides via `*.local.yaml`.
 
-**Handoff pointer (fresh-session start here):** the fresh-rig battery
-rerun is DONE (2026-07-10 late: **6/12 clean**, 12.5 min, zero
-timeouts — see the trajectory table; yesterday's 3/12 was infra, not
-regression). NEXT: the **fix-execution rung** (chain write → run →
-verdict inside one fix turn). The seams are mapped and exactly two
-structural blockers exist: a write continuation is terminal
-(`_resumes_turn` excludes write, `serving_ensemble_caller.py`) and
-classify suppresses the run signal whenever a fix/build verb is present
-(`classify.py` `_route`); the composition is fix-intent writes resume +
-a wrote-block→need-run signal mirroring `has_run_block`→run-verdict.
-The rerun also surfaced, in priority order behind fix-execution: the
-series' first two DISHONEST misses (turn 3 speculated about a
-never-built file — the grounded-explain gap; turn 10 wrong recall —
-#82), and a cross-turn-repair observation (turn 2 could have rebuilt
-the never-built todo.py from conversation intent instead of cascading —
-a detectable deterministic condition; sibling rung to fix-execution,
-not scope creep). Then: **rewrite negation-tightening**
-(expectation-adjacent tokens only;
-`docs/plans/2026-07-10-test-repair-round-2-design.md`), the **#82
-deep-recall remainder**, and the import-guard residual. The recorded
-battery is `benchmarks/agentic_serving/ladder_battery.sh` (series 4/10
-→ 7/10 → 6/11 → 5/11 → 9/11 → 6/11 → 3/12-infra → 6/12; run-to-run
-variance ≈ 5 points on whether turn 1's build lands). Standing smaller
-follow-ups: #110, the injector's scope-blind binding, #106, the serve
-trace's ~280-char node-response truncation (blocks post-hoc held-round
-diagnosis), and the glob-result verbatim wire capture (the wire log is
-shape-only — a capture needs a body-dumping probe, not
-LLM_ORC_SERVE_WIRE_LOG). #107 is fixed (PR #113:
-endpoint-boundary `_text_content` normalizer — the 422 fired at
-pydantic before the caller could crash; textless/malformed parts
-lists still 422 honestly rather than sliding the turn boundary). Ops notes: the
-harness reaps tracked background serves/batteries mid-long-run — start
-them detached (nohup + disown) with a Monitor tail; give the rig
-cooling headroom between batteries.
+**Handoff pointer (fresh-session start here):** the **fix-execution
+rung is IMPLEMENTED** (2026-07-10 late, branch worktree-fix-execution;
+design `docs/plans/2026-07-10-fix-execution-design.md`): a fix-intent
+turn's applied write resumes the pipeline and chains into the existing
+run seam (structural `wrote_path` from the caller's post-boundary
+tool_calls → classify `fix_chain` → need-run → run-verdict), so the
+client's real suite judges the fix — the blind spot the server-side
+gate structurally cannot cover. Live-proven twice: a real-OpenCode fix
+turn whose seat-accepted rewrite did NOT fix the bug got an honest red
+verdict from its own chained run, and battery turn 13 additionally
+surfaced the exact expected-vs-actual assertion mismatch in the
+verdict. NEXT, in leverage order: (1) **rung 2 — bounded re-fix on a
+red chained verdict**, carrying the verdict's failure report back into
+one held-style retry (the verdict already contains exactly the carry;
+composes with #100's machinery); (2) **rung 1.5 — read the visible
+test_<stem>.py when fixing <stem>.py** (deterministic, one read round;
+would likely have converted battery turn 13, whose fix invented its own
+exception message because it never saw the seeded test); (3) the
+**grounded-explain gap** (turn 3 keeps speculating about a never-built
+file) and **#82 deep recall** (turn 10 wrong again); (4) cross-turn
+repair (sibling rung, named in the design doc); (5) rewrite
+negation-tightening (`docs/plans/2026-07-10-test-repair-round-2-design.md`)
+and the import-guard residual. The recorded battery is
+`benchmarks/agentic_serving/ladder_battery.sh`, now 13 turns (series
+4/10 → 7/10 → 6/11 → 5/11 → 9/11 → 6/11 → 3/12-infra → 6/12 → 6/13;
+run-to-run variance ≈ 5 points on whether turn 1's build lands; turn
+2's 600s client timeout vs the seat's 720s two-round budget is a
+standing latency tension). Standing smaller follow-ups: #110, #114
+(trace truncation — blocks post-hoc held-round diagnosis), the
+injector's scope-blind binding, #106, the chain's "existing"-verb
+width (battery turn 8's tests-turn chained an honest whole-suite
+report — informative but undesigned; keep or narrow on review), and
+the glob-result verbatim wire capture (the wire log is shape-only — a
+capture needs a body-dumping probe, not LLM_ORC_SERVE_WIRE_LOG). Ops
+notes: the harness reaps tracked background serves/batteries
+mid-long-run — start them detached (nohup + disown) with a Monitor
+tail; give the rig cooling headroom between batteries.
 
 Key empirical facts the next work builds on:
 

--- a/docs/serving-roadmap.md
+++ b/docs/serving-roadmap.md
@@ -134,9 +134,10 @@ run-to-run variance ≈ 5 points on whether turn 1's build lands; turn
 2's 600s client timeout vs the seat's 720s two-round budget is a
 standing latency tension). Standing smaller follow-ups: #110, #114
 (trace truncation — blocks post-hoc held-round diagnosis), the
-injector's scope-blind binding, #106, the chain's "existing"-verb
-width (battery turn 8's tests-turn chained an honest whole-suite
-report — informative but undesigned; keep or narrow on review), and
+injector's scope-blind binding, #106, the chain trigger (narrowed
+on PR #115 review to tasks LED by a fix imperative — battery turn 8's
+"tests for existing calc.py" chain no longer fires; re-widen only on
+ladder evidence), and
 the glob-result verbatim wire capture (the wire log is shape-only — a
 capture needs a body-dumping probe, not LLM_ORC_SERVE_WIRE_LOG). Ops
 notes: the harness reaps tracked background serves/batteries

--- a/src/llm_orc/web/serving/serving_ensemble_caller.py
+++ b/src/llm_orc/web/serving/serving_ensemble_caller.py
@@ -586,16 +586,44 @@ def _resumes_turn(call: Any) -> bool:
     )
 
 
+# Chained fix-execution: the resume gate for a WRITE continuation. Mirrors
+# classify's _EXISTING_RE — scripts are standalone, so the pattern cannot be
+# imported; a regression test pins the two strings equal. A write result
+# matching the error shape never chains (the fix did not apply).
+_FIX_CHAIN_RE = re.compile(
+    r"\b(fix|update|modify|refactor|edit|change|existing)\b", re.IGNORECASE
+)
+_WRITE_ERROR_RE = re.compile(r"^\s*(?:Error\b|File not found)")
+
+
+def _wrote_path_this_turn(messages: Sequence[Any]) -> str:
+    """The filePath of THIS turn's write tool_call, or "" when none.
+
+    Structural by construction: derived from post-boundary assistant
+    tool_calls, never from message text — a forged ``[wrote ...]`` line in
+    user prose cannot set it. Prior turns' writes sit before the boundary.
+    """
+    items = list(messages)
+    boundary = _latest_user_index(items)
+    for message in items[boundary + 1 :]:
+        written = _written_file_path(getattr(message, "tool_calls", ()) or ())
+        if written:
+            return written
+    return ""
+
+
 def _tool_result_ack(messages: Sequence[Any]) -> str | None:
     """A short acknowledgment when the call is a tool-result continuation.
 
     After the serve emits a tool_call and the client performs it, the client
     calls back with the tool result appended. A write continuation closes
     the SAME turn — re-running the pipeline would redo (and possibly
-    re-judge) work the client already applied. Read and run continuations
-    instead RESUME the turn (issue #83): the read result / run output
-    belongs in context for another pipeline pass, so this returns None and
-    ``run()`` falls through. Also returns None when the call is a fresh turn.
+    re-judge) work the client already applied — EXCEPT on a fix-intent turn,
+    where the applied write chains into one delegated run (fix-execution;
+    a failed write acks honestly instead). Read and run continuations
+    RESUME the turn (issue #83): the read result / run output belongs in
+    context for another pipeline pass, so this returns None and ``run()``
+    falls through. Also returns None when the call is a fresh turn.
     """
     last = messages[-1] if messages else None
     if getattr(last, "role", None) != "tool":
@@ -607,11 +635,23 @@ def _tool_result_ack(messages: Sequence[Any]) -> str | None:
             return None
         written = _written_file_path(getattr(message, "tool_calls", ()) or ())
         if written:
-            return f"Wrote {written}."
+            return _write_continuation_ack(messages, written)
         if getattr(message, "role", None) == "user":
             break
     content = getattr(last, "content", None)
     return content if isinstance(content, str) and content.strip() else "Done."
+
+
+def _write_continuation_ack(messages: Sequence[Any], written: str) -> str | None:
+    """Terminal ack for a write continuation — or None when the fix chain
+    resumes. A fix-intent turn's applied write chains into one delegated
+    run (fix-execution); a failed write acks honestly and never chains."""
+    if not _FIX_CHAIN_RE.search(_task_from(messages)):
+        return f"Wrote {written}."
+    result = getattr(messages[-1], "content", None)
+    if isinstance(result, str) and _WRITE_ERROR_RE.match(result):
+        return f"Write failed for {written}."
+    return None
 
 
 def _written_file_path(tool_calls: Sequence[Any]) -> str | None:
@@ -745,16 +785,23 @@ class ServingEnsembleCaller:
             yield Completion(finish_reason="stop")
             return
         outcome = await self._serve(
-            _task_from(context.messages), _render_context(context.messages)
+            _task_from(context.messages),
+            _render_context(context.messages),
+            wrote_path=_wrote_path_this_turn(context.messages),
         )
         for chunk in _outcome_chunks(outcome, context.tools):
             yield chunk
 
-    async def _serve(self, task: str, conversation: str = "") -> dict[str, Any]:
+    async def _serve(
+        self, task: str, conversation: str = "", wrote_path: str = ""
+    ) -> dict[str, Any]:
         config = self._load_config()
         executor = ExecutorFactory.create_root_executor(project_dir=self._project_dir)
         result = await executor.execute(
-            config, json.dumps({"task": task, "context": conversation})
+            config,
+            json.dumps(
+                {"task": task, "context": conversation, "wrote_path": wrote_path}
+            ),
         )
         # blocking file I/O off the event loop so concurrent SSE streams
         # never stall on the trace flush (issue #93)

--- a/src/llm_orc/web/serving/serving_ensemble_caller.py
+++ b/src/llm_orc/web/serving/serving_ensemble_caller.py
@@ -207,6 +207,16 @@ def _render_context(messages: Sequence[Any]) -> str:
         # line-anchored, and a partial '[wrote ...]' header corrupts it
         cut = rendered.find("\n")
         rendered = rendered[cut + 1 :] if cut >= 0 else rendered
+        # and the cut block's remaining fence-indented body lines: headerless,
+        # they would continue whatever kept block precedes the tail — a [ran]
+        # block's summary drowned under them (PR #115 review)
+        tail_lines = rendered.split("\n")
+        start = 0
+        while start < len(tail_lines) and (
+            not tail_lines[start] or tail_lines[start].startswith("  ")
+        ):
+            start += 1
+        rendered = "\n".join(tail_lines[start:])
 
     task = _task_from(messages)
     # select over the FULL prior history, not just pre-tail messages: the
@@ -586,14 +596,30 @@ def _resumes_turn(call: Any) -> bool:
     )
 
 
-# Chained fix-execution: the resume gate for a WRITE continuation. Mirrors
-# classify's _EXISTING_RE — scripts are standalone, so the pattern cannot be
-# imported; a regression test pins the two strings equal. A write result
-# matching the error shape never chains (the fix did not apply).
+# Chained fix-execution: the resume gate for a WRITE continuation. Only a
+# task LED by a fix imperative chains — mid-sentence "existing"/"change"
+# are ordinary build prose (PR #115 review). Mirrors classify's
+# _FIX_VERB_RE — scripts are standalone, so the pattern cannot be
+# imported; a regression test pins pattern and flags equal.
 _FIX_CHAIN_RE = re.compile(
-    r"\b(fix|update|modify|refactor|edit|change|existing)\b", re.IGNORECASE
+    r"^\s*(?:fix|update|modify|refactor|edit|change)\b", re.IGNORECASE
 )
-_WRITE_ERROR_RE = re.compile(r"^\s*(?:Error\b|File not found)")
+
+
+def _write_result_failed(result: Any) -> bool:
+    """True when a write tool result carries a failure (or no evidence of
+    success): a failed write must never chain — the verdict would frame an
+    unapplied fix as verified. Mirrors the read path's lowercased prefixes
+    and adds the client permission-denial and empty-result shapes
+    (PR #115 review blocker)."""
+    if not isinstance(result, str) or not result.strip():
+        return True
+    lowered = result.strip().lower()
+    return (
+        lowered.startswith("error")
+        or lowered.startswith("file not found")
+        or "rejected permission" in lowered
+    )
 
 
 def _wrote_path_this_turn(messages: Sequence[Any]) -> str:
@@ -644,12 +670,11 @@ def _tool_result_ack(messages: Sequence[Any]) -> str | None:
 
 def _write_continuation_ack(messages: Sequence[Any], written: str) -> str | None:
     """Terminal ack for a write continuation — or None when the fix chain
-    resumes. A fix-intent turn's applied write chains into one delegated
+    resumes. A fix-led turn's applied write chains into one delegated
     run (fix-execution); a failed write acks honestly and never chains."""
-    if not _FIX_CHAIN_RE.search(_task_from(messages)):
+    if not _FIX_CHAIN_RE.match(_task_from(messages)):
         return f"Wrote {written}."
-    result = getattr(messages[-1], "content", None)
-    if isinstance(result, str) and _WRITE_ERROR_RE.match(result):
+    if _write_result_failed(getattr(messages[-1], "content", None)):
         return f"Write failed for {written}."
     return None
 

--- a/tests/unit/serving/test_serving_classify.py
+++ b/tests/unit/serving/test_serving_classify.py
@@ -663,3 +663,16 @@ def test_fix_turn_without_a_write_takes_the_read_seam_not_the_chain() -> None:
     decision = _classify({"task": "fix the divide bug in calc.py"})
     assert decision["target"] == "need-files"
     assert decision["needs_files"] == ["calc.py"]
+
+
+def test_mid_sentence_edit_words_never_chain_even_with_a_write() -> None:
+    # PR #115 review: "existing"/"change" as mid-sentence prose are ordinary
+    # build words; only a leading fix imperative chains. (These turns keep
+    # their pre-existing routes — the read-first seam via _EXISTING_RE is
+    # untouched; they just never enter the run chain.)
+    for task in (
+        "write add.py so the existing tests pass",
+        "write tests for existing calc.py",
+    ):
+        decision = _classify({"task": task, "wrote_path": "add.py"})
+        assert decision["target"] not in ("need-run", "run-verdict"), task

--- a/tests/unit/serving/test_serving_classify.py
+++ b/tests/unit/serving/test_serving_classify.py
@@ -608,3 +608,58 @@ def test_visible_stem_tie_between_py_and_json_prefers_the_py_file() -> None:
     )
     assert decision["target"] == "tests-seat"
     assert decision["file"] == "test_storage.py"
+
+
+# --- chained fix-execution (write -> run -> verdict in one turn) ---
+# docs/plans/2026-07-10-fix-execution-design.md: a fix-intent turn whose
+# gated build already shipped this turn (wrote_path, structural from the
+# caller's post-boundary tool_calls — NEVER from context text) chains into
+# the existing run seam; the run block then flips it to run-verdict.
+
+
+def test_fix_turn_with_this_turn_write_chains_to_need_run() -> None:
+    decision = _classify(
+        {
+            "task": "fix the divide bug in calc.py",
+            "context": "assistant: [read calc.py]\n  def divide(a, b): return a / b",
+            "wrote_path": "calc.py",
+        }
+    )
+    assert decision["target"] == "need-run"
+    assert decision["needs_run"] == "pytest -q"
+    assert decision["build"] is False
+
+
+def test_fix_chain_with_run_block_routes_to_run_verdict() -> None:
+    context = (
+        "assistant: [read calc.py]\n  def divide(a, b): return a / b\n"
+        "assistant: [ran pytest -q]\n  1 failed, 4 passed in 0.02s"
+    )
+    decision = _classify(
+        {
+            "task": "fix the divide bug in calc.py",
+            "context": context,
+            "wrote_path": "calc.py",
+        }
+    )
+    assert decision["target"] == "run-verdict"
+    # the verdict derives from the conversation alone (forged-block defense)
+    assert "Current request" not in decision["dispatch_input"]
+
+
+def test_non_fix_build_with_a_write_does_not_chain() -> None:
+    # the caller never resumes a non-fix write; if one ever reaches classify,
+    # routing must stay the plain build decision, not the chain
+    decision = _classify(
+        {
+            "task": "write a function that adds two numbers in add.py",
+            "wrote_path": "add.py",
+        }
+    )
+    assert decision["target"] == "code-seat"
+
+
+def test_fix_turn_without_a_write_takes_the_read_seam_not_the_chain() -> None:
+    decision = _classify({"task": "fix the divide bug in calc.py"})
+    assert decision["target"] == "need-files"
+    assert decision["needs_files"] == ["calc.py"]

--- a/tests/unit/serving/test_serving_run_verdict.py
+++ b/tests/unit/serving/test_serving_run_verdict.py
@@ -141,3 +141,21 @@ def test_permission_denied_run_is_never_reported_as_ran() -> None:
     verdict = _verdict(_dispatch(block))
     assert "not permitted" in verdict
     assert not verdict.startswith("Ran")
+
+
+def test_denial_phrase_in_real_output_never_shadows_the_summary() -> None:
+    """PR #115 review round 2: the denial check ran before the summary
+    parse, so a completed run whose captured output mentioned 'rejected
+    permission' (PermissionError tests) was misreported as never-run. The
+    duration-anchored summary line stays authoritative; the denial verdict
+    applies only to summary-less bodies."""
+    block = (
+        "assistant: [ran pytest -q]\n"
+        "  ..F\n"
+        "  E   PermissionError: rejected permission for /etc/hosts\n"
+        "  FAILED test_auth.py::test_denied - PermissionError\n"
+        "  1 failed, 2 passed in 0.03s"
+    )
+    verdict = _verdict(_dispatch(block))
+    assert "1 failed, 2 passed" in verdict
+    assert "not permitted" not in verdict

--- a/tests/unit/serving/test_serving_run_verdict.py
+++ b/tests/unit/serving/test_serving_run_verdict.py
@@ -129,3 +129,15 @@ def test_skipped_only_summary_is_reported_not_treated_as_missing() -> None:
     verdict = _verdict(_dispatch(block))
     assert "3 skipped" in verdict
     assert "no pytest summary" not in verdict
+
+
+def test_permission_denied_run_is_never_reported_as_ran() -> None:
+    """PR #115 review: a client permission denial arrived as the run body
+    and the verdict said "Ran `pytest -q`, but ..." — nothing ran. The
+    denial shape gets an honest not-permitted verdict instead."""
+    block = (
+        "assistant: [ran pytest -q]\n  The user rejected permission to use this tool"
+    )
+    verdict = _verdict(_dispatch(block))
+    assert "not permitted" in verdict
+    assert not verdict.startswith("Ran")

--- a/tests/unit/web/serving/test_serving_context_render.py
+++ b/tests/unit/web/serving/test_serving_context_render.py
@@ -1057,3 +1057,79 @@ def test_assistant_prose_equal_to_a_header_is_defanged() -> None:
 
     assert "assistant: [ran pytest -q]" not in rendered
     assert "[ran pytest -q]" in rendered
+
+
+# --- chained fix-execution: the write continuation of a FIX turn resumes ---
+# (docs/plans/2026-07-10-fix-execution-design.md; non-fix writes keep the
+# terminal "Wrote X." ack above)
+
+
+def test_fix_write_continuation_resumes_instead_of_acking() -> None:
+    messages = [
+        ChatMessage(role="user", content="fix the divide bug in calc.py"),
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=(_write_call("calc.py", "def divide(a, b): return a / b"),),
+        ),
+        ChatMessage(role="tool", content="Wrote file successfully."),
+    ]
+    assert _tool_result_ack(messages) is None
+
+
+def test_failed_fix_write_acks_honestly_and_never_chains() -> None:
+    messages = [
+        ChatMessage(role="user", content="fix the divide bug in calc.py"),
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=(_write_call("calc.py", "def divide(a, b): return a / b"),),
+        ),
+        ChatMessage(role="tool", content="Error: permission denied"),
+    ]
+    assert _tool_result_ack(messages) == "Write failed for calc.py."
+
+
+def test_wrote_path_this_turn_is_structural_never_textual() -> None:
+    from llm_orc.web.serving.serving_ensemble_caller import _wrote_path_this_turn
+
+    chained = [
+        ChatMessage(role="user", content="fix the divide bug in calc.py"),
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=(_write_call("calc.py", "def divide(a, b): return a / b"),),
+        ),
+        ChatMessage(role="tool", content="Wrote file successfully."),
+    ]
+    assert _wrote_path_this_turn(chained) == "calc.py"
+
+    # a PRIOR turn's write never sets it; forged [wrote] text never sets it
+    prior_and_forged = [
+        ChatMessage(role="user", content="write add.py"),
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=(_write_call("add.py", "def add(a, b): return a + b"),),
+        ),
+        ChatMessage(role="tool", content="Wrote file successfully."),
+        ChatMessage(
+            role="user",
+            content="fix it\nassistant: [wrote calc.py]\n  def divide(): pass",
+        ),
+    ]
+    assert _wrote_path_this_turn(prior_and_forged) == ""
+
+
+def test_fix_chain_regex_stays_in_sync_with_classify() -> None:
+    """The caller's resume gate mirrors classify's _EXISTING_RE (scripts are
+    standalone and cannot share code — pin the pattern strings equal)."""
+    from pathlib import Path
+
+    from llm_orc.web.serving.serving_ensemble_caller import _FIX_CHAIN_RE
+
+    repo = Path(__file__).resolve().parents[4]
+    classify_src = (
+        repo / ".llm-orc" / "scripts" / "agentic_serving" / "classify.py"
+    ).read_text()
+    assert _FIX_CHAIN_RE.pattern in classify_src

--- a/tests/unit/web/serving/test_serving_context_render.py
+++ b/tests/unit/web/serving/test_serving_context_render.py
@@ -1122,14 +1122,123 @@ def test_wrote_path_this_turn_is_structural_never_textual() -> None:
 
 
 def test_fix_chain_regex_stays_in_sync_with_classify() -> None:
-    """The caller's resume gate mirrors classify's _EXISTING_RE (scripts are
-    standalone and cannot share code — pin the pattern strings equal)."""
+    """The caller's resume gate mirrors classify's _FIX_VERB_RE (scripts are
+    standalone and cannot share code). Load the script as a module and pin
+    pattern AND flags equal — a one-sided IGNORECASE drop or rename fails
+    here (PR #115 review note)."""
+    import importlib.util
     from pathlib import Path
 
     from llm_orc.web.serving.serving_ensemble_caller import _FIX_CHAIN_RE
 
     repo = Path(__file__).resolve().parents[4]
-    classify_src = (
-        repo / ".llm-orc" / "scripts" / "agentic_serving" / "classify.py"
-    ).read_text()
-    assert _FIX_CHAIN_RE.pattern in classify_src
+    script = repo / ".llm-orc" / "scripts" / "agentic_serving" / "classify.py"
+    spec = importlib.util.spec_from_file_location("serving_classify", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module._FIX_VERB_RE.pattern == _FIX_CHAIN_RE.pattern
+    assert module._FIX_VERB_RE.flags == _FIX_CHAIN_RE.flags
+
+
+def test_failed_write_shapes_all_ack_honestly_and_never_chain() -> None:
+    """PR #115 review blocker: the error match was case-sensitive and blind
+    to OpenCode's permission-denial and empty-result shapes — a write that
+    never applied chained anyway and the verdict framed an unapplied fix
+    as verified. All failure shapes must ack terminal, mirroring the read
+    path's lowercased prefixes."""
+    for failed_result in (
+        "error: EACCES: permission denied",
+        "Error: something broke",
+        "File not found: calc.py",
+        "The user rejected permission to use this tool",
+        "",
+        "   ",
+        None,
+    ):
+        messages = [
+            ChatMessage(role="user", content="fix the divide bug in calc.py"),
+            ChatMessage(
+                role="assistant",
+                content=None,
+                tool_calls=(_write_call("calc.py", "def divide(): pass"),),
+            ),
+            ChatMessage(role="tool", content=failed_result),
+        ]
+        assert _tool_result_ack(messages) == "Write failed for calc.py.", failed_result
+
+
+def test_chain_trigger_requires_a_leading_fix_imperative() -> None:
+    """PR #115 review should-fix: mid-sentence 'existing'/'change' nouns and
+    adjectives are ordinary build prose — only a task LED by a fix
+    imperative chains. Fresh-create and tests-seat turns keep the terminal
+    ack even when their prose mentions existing code."""
+    for non_fix_task, path in (
+        ("write add.py so the existing tests pass", "add.py"),
+        ("write tests for existing calc.py", "test_calc.py"),
+    ):
+        messages = [
+            ChatMessage(role="user", content=non_fix_task),
+            ChatMessage(
+                role="assistant",
+                content=None,
+                tool_calls=(_write_call(path, "x = 1"),),
+            ),
+            ChatMessage(role="tool", content="Wrote file successfully."),
+        ]
+        assert _tool_result_ack(messages) == f"Wrote {path}.", non_fix_task
+
+
+def test_decapitated_tail_never_continues_a_kept_run_block() -> None:
+    """PR #115 review: when the tail cap slices mid-write-body, the cut
+    body's fence-indented lines abutted the kept [ran] block and swallowed
+    the pytest summary — a real '2 failed, 1 passed' verdict degraded to
+    'no pytest summary'. After decapitation the tail must resume at a
+    column-0 line."""
+    messages: list[ChatMessage] = []
+    for i in range(4):
+        big_body = f"def f{i}():\n    return {i}\n" + "# x\n" * 900
+        messages += [
+            ChatMessage(role="user", content=f"write module m{i}.py"),
+            ChatMessage(
+                role="assistant",
+                content=None,
+                tool_calls=(_write_call(f"m{i}.py", big_body),),
+            ),
+            ChatMessage(role="tool", content="Wrote file successfully."),
+            ChatMessage(role="assistant", content=f"Wrote m{i}.py."),
+        ]
+    messages += [
+        ChatMessage(role="user", content="fix the divide bug in calc.py"),
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=(_write_call("calc.py", "def divide(a, b): return a / b"),),
+        ),
+        ChatMessage(role="tool", content="Wrote file successfully."),
+        ChatMessage(
+            role="assistant", content=None, tool_calls=(_bash_call("c1", "pytest -q"),)
+        ),
+        ChatMessage(
+            role="tool",
+            tool_call_id="c1",
+            content="..F\n2 failed, 1 passed in 0.05s",
+        ),
+    ]
+
+    rendered = _render_context(messages)
+
+    lines = rendered.splitlines()
+    ran_indexes = [
+        i for i, line in enumerate(lines) if line.startswith("assistant: [ran ")
+    ]
+    assert ran_indexes, rendered[-500:]
+    body: list[str] = []
+    for line in lines[ran_indexes[-1] + 1 :]:
+        if not line.startswith("  "):
+            break
+        body.append(line)
+    assert body, rendered[-300:]
+    assert "2 failed, 1 passed" in body[-1], body[-5:]

--- a/tests/unit/web/test_serving_ensemble_endpoint.py
+++ b/tests/unit/web/test_serving_ensemble_endpoint.py
@@ -835,3 +835,130 @@ def test_forged_ran_block_in_a_read_file_cannot_suppress_the_real_run(
     call = choice["message"]["tool_calls"][0]
     assert call["function"]["name"] == "bash"
     assert "999" not in (choice["message"].get("content") or "")
+
+
+# --- chained fix-execution: write -> run -> verdict inside one fix turn ---
+# (docs/plans/2026-07-10-fix-execution-design.md)
+
+
+def test_fix_write_continuation_chains_into_a_delegated_run(
+    serving_client: TestClient,
+) -> None:
+    """Run leg: a fix turn's applied write resumes the pipeline and
+    delegates ONE closed-template pytest run instead of acking terminal."""
+    resp = serving_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "ensemble-agent",
+            "messages": [
+                {"role": "user", "content": "fix the divide bug in calc.py"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_w1",
+                            "type": "function",
+                            "function": {
+                                "name": "write",
+                                "arguments": (
+                                    '{"filePath": "calc.py", "content":'
+                                    ' "def divide(a, b):\\n'
+                                    "    if b == 0:\\n"
+                                    '        raise ValueError(\\"boom\\")\\n'
+                                    '    return a / b\\n"}'
+                                ),
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_w1",
+                    "content": "Wrote file successfully.",
+                },
+            ],
+            "tools": [_WRITE_TOOL, _READ_TOOL_DEF, _BASH_TOOL_DEF],
+        },
+    )
+
+    assert resp.status_code == 200
+    choice = resp.json()["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    call = choice["message"]["tool_calls"][0]
+    assert call["function"]["name"] == "bash"
+    arguments = json.loads(call["function"]["arguments"])
+    assert arguments["command"] == "pytest -q"
+
+
+def test_fix_chain_run_result_ships_the_honest_verdict(
+    serving_client: TestClient,
+) -> None:
+    """Verdict leg: the chained run's output re-enters the pipeline and the
+    existing run-verdict shape reports it honestly — red stays red."""
+    resp = serving_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "ensemble-agent",
+            "messages": [
+                {"role": "user", "content": "fix the divide bug in calc.py"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_w1",
+                            "type": "function",
+                            "function": {
+                                "name": "write",
+                                "arguments": (
+                                    '{"filePath": "calc.py", "content":'
+                                    ' "def divide(a, b): return a / b\\n"}'
+                                ),
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_w1",
+                    "content": "Wrote file successfully.",
+                },
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_b1",
+                            "type": "function",
+                            "function": {
+                                "name": "bash",
+                                "arguments": (
+                                    '{"command": "pytest -q",'
+                                    ' "description": "Run tests"}'
+                                ),
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_b1",
+                    "content": (
+                        "F....\n"
+                        "FAILED test_calc.py::test_divide_zero - ValueError\n"
+                        "1 failed, 4 passed in 0.03s"
+                    ),
+                },
+            ],
+            "tools": [_WRITE_TOOL, _READ_TOOL_DEF, _BASH_TOOL_DEF],
+        },
+    )
+
+    assert resp.status_code == 200
+    choice = resp.json()["choices"][0]
+    assert choice["finish_reason"] == "stop"
+    assert not choice["message"].get("tool_calls")
+    content = choice["message"]["content"]
+    assert "1 failed, 4 passed" in content
+    assert "FAILED test_calc.py::test_divide_zero" in content


### PR DESCRIPTION
## What

The rung the roadmap names as pure composition of the shipped #83 seams (design: `docs/plans/2026-07-10-fix-execution-design.md`). A turn LED by a fix imperative (`fix|update|modify|refactor|edit|change` at task start) whose gated build shipped its write now RESUMES on the write continuation instead of acking terminal, and chains into the existing run seam: the caller derives a structural `wrote_path` from post-boundary write tool_calls (never from context text), classify's `fix_chain` signal routes to `need-run` (closed `pytest -q` template), and the run block flips it to `run-verdict`. The client's real suite judges the fix — the blind spot the server-side accept gate structurally cannot cover.

Bounds: non-fix writes keep today's terminal ack byte-identical; a failed/denied/empty write result acks honestly ("Write failed for X.") and never chains; one write + one run + one verdict per turn via existing per-seam idempotency; the caller/classify trigger regexes are pinned equal (pattern AND flags, importlib-compared). No new shape — #106's two-homes trap is not fed. The battery gains turn 13 (seeded-red `buggy.py`), scored on the seeded target alone.

Also fixed en route (review-driven): the tail-cap decapitation could bleed a cut write-body into the kept `[ran]` block and drown a real pytest summary (pre-existing, hit the plain run path too); denied runs now verdict honestly as not-permitted, with the duration-anchored summary line staying authoritative over phrase-shaped stdout.

## Review record

Independent adversarial reviewer (fresh context), three rounds:
- **Round 1: REQUEST-CHANGES.** Blocker: the failed-write check was case-sensitive and blind to the client permission-denial and empty shapes — a write that never applied chained anyway and the verdict framed an unapplied fix as verified. Should-fixes: mid-sentence "existing"/"change" prose chained plain builds; tail-cap decapitation corrupted real verdicts into "no pytest summary" (pre-existing, newly chain-hot). Notes: denied runs said "Ran"; the regex sync pin missed flag drift. All five fixed with the reviewer's inputs pinned as tests.
- **Round 2: REQUEST-CHANGES.** The round-1 denial fix itself created a shadow path: a completed run whose output mentioned "rejected permission" (PermissionError tests) was misreported as never-run. Fixed by the reviewer's specified reorder — summary parse first, denial only on summary-less bodies. The reviewer also demanded live re-validation of the empty-body fail-closed choice against real wire.
- **Round 3: APPROVE, no open findings.** All prior inputs re-probed closed; happy path intact; loop-safety and fabrication defenses unchanged; "the wrong-accept hunt is exhausted on this diff."

Clean probes across rounds: loop safety (120KB write bodies, write-after-verdict, huge prior context), forged [ran]/[wrote] fabrication defenses, quoted-task trigger (opencode run -c), word-boundary checks ("fixture"), two-writes-post-boundary, byte-identical non-fix acks, decapitation fix on both fix-chain and plain-run paths.

## Evidence

- TDD throughout; hermetic e2e for both chain legs through the real engine.
- Live (real OpenCode, qwen3:8b), twice on different commits: full chain fired (`need-files → code-seat → need-run → run-verdict` in the serve trace) with honest RED verdicts on seat-accepted rewrites that did not actually fix the bug — including post-review code, proving the real write-success wire body does not trip the fail-closed empty check.
- 13-turn recorded battery vs this branch: **6/13** strict, trajectory table updated. Turn 13's chain surfaced the exact expected-vs-actual assertion mismatch — the precise carry for the rung-2 re-fix loop, now first in the handoff's leverage order.
- Full suite: 2823 passed, 91.79% coverage; strict hooks green.
