### PR TITLE
Pre-release cleanups: trace diagnostics (#114), blank-user-message rejection, battery cap

### DIFF
--- a/benchmarks/agentic_serving/ladder_battery.sh
+++ b/benchmarks/agentic_serving/ladder_battery.sh
@@ -43,6 +43,9 @@
 # alone so earlier turns' residue cannot cascade into this rung. An
 # honest red verdict on an unfixed bug is an honest miss; a verdict that
 # contradicts client ground truth is a dishonest one.
+# Turn cap: 780s = the seat's 720s two-round budget + margin. 600s lost a
+# turn to a client timeout while the seat was still inside its budget
+# (2026-07-10 13-turn run, turn 2).
 set -u
 REPO=${LADDER_REPO:?set LADDER_REPO to a seeded scratch repo}
 OUT=${LADDER_OUT:?set LADDER_OUT to an output dir}
@@ -69,10 +72,10 @@ for p in "${PROMPTS[@]}"; do
   i=$((i+1))
   echo "=== TURN $i: $p ==="
   if [ $i -eq 1 ]; then
-    timeout 600 opencode run -m llm-orc/agentic "$p" \
+    timeout 780 opencode run -m llm-orc/agentic "$p" \
       > "$OUT/turn-$(printf %02d $i).out" 2>&1
   else
-    timeout 600 opencode run -c -m llm-orc/agentic "$p" \
+    timeout 780 opencode run -c -m llm-orc/agentic "$p" \
       > "$OUT/turn-$(printf %02d $i).out" 2>&1
   fi
   echo "--- exit $? ---"

--- a/src/llm_orc/web/api/v1_chat_completions.py
+++ b/src/llm_orc/web/api/v1_chat_completions.py
@@ -175,18 +175,24 @@ class _ChatCompletionMessage(BaseModel):
         return value
 
     @model_validator(mode="after")
-    def _user_parts_carry_text(self) -> _ChatCompletionMessage:
-        """Reject a USER parts message whose text joins to blank.
+    def _user_content_carries_text(self) -> _ChatCompletionMessage:
+        """Reject a USER message whose content is blank — parts joining to
+        nothing (PR #113 review blocker) or a blank/empty string (the same
+        review's standing observation, the string-shaped twin).
 
         Empty user content silently slides the turn boundary back to a
-        stale task (PR #113 review blocker). Scoped to user messages:
-        only they feed ``_task_from``/``_latest_user_index``, and an
-        empty tool result as parts is wire-legal (silent-success
-        commands) with an honest empty-string render.
+        stale task. Scoped to user messages: only they feed
+        ``_task_from``/``_latest_user_index``, and an empty tool result is
+        wire-legal (silent-success commands) with an honest empty render.
+        ``content: null`` stays legal on every role per the OpenAI shape.
         """
-        if self.role == "user" and isinstance(self.content, list):
+        if self.role != "user" or self.content is None:
+            return self
+        if isinstance(self.content, list):
             if not _joined_text_parts(self.content).strip():
                 raise ValueError("user content parts carry no text to route on")
+        elif not self.content.strip():
+            raise ValueError("user content is blank; nothing to route on")
         return self
 
 

--- a/src/llm_orc/web/api/v1_chat_completions.py
+++ b/src/llm_orc/web/api/v1_chat_completions.py
@@ -184,10 +184,15 @@ class _ChatCompletionMessage(BaseModel):
         stale task. Scoped to user messages: only they feed
         ``_task_from``/``_latest_user_index``, and an empty tool result is
         wire-legal (silent-success commands) with an honest empty render.
-        ``content: null`` stays legal on every role per the OpenAI shape.
+        ``content: null`` stays legal on the other roles (an assistant
+        tool_calls turn carries null content per the OpenAI shape) but is
+        the third twin of the slide on user messages — OpenAI requires
+        user content, so it 422s here too (PR #116 review).
         """
-        if self.role != "user" or self.content is None:
+        if self.role != "user":
             return self
+        if self.content is None:
+            raise ValueError("user content is required")
         if isinstance(self.content, list):
             if not _joined_text_parts(self.content).strip():
                 raise ValueError("user content parts carry no text to route on")

--- a/src/llm_orc/web/serving/turn_trace.py
+++ b/src/llm_orc/web/serving/turn_trace.py
@@ -128,7 +128,10 @@ def emit_turn_trace(
     """Build the turn trace, append it to ``<root>/turns.jsonl``, and write a
     one-line summary to stderr. Returns the trace so callers/tests can inspect
     it. Tracing must never break the serve, so IO failures are swallowed."""
-    trace = build_turn_trace(ensemble_name, result_dict)
+    try:
+        trace = build_turn_trace(ensemble_name, result_dict)
+    except Exception:  # noqa: BLE001 — tracing must never break the serve
+        trace = {"ensemble": ensemble_name, "execution_order": [], "nodes": []}
     try:
         root.mkdir(parents=True, exist_ok=True)
         with (root / "turns.jsonl").open("a", encoding="utf-8") as handle:

--- a/src/llm_orc/web/serving/turn_trace.py
+++ b/src/llm_orc/web/serving/turn_trace.py
@@ -55,6 +55,42 @@ def _child_results(response: Any) -> dict[str, Any] | None:
     return results if isinstance(results, dict) else None
 
 
+def _diagnostics(response: Any) -> dict[str, Any] | None:
+    """The envelope's structured ``diagnostics`` dict when ``response`` is a
+    (possibly output-wrapped) envelope JSON. The small typed verdict fields —
+    accept, held_round, tests_pass/adequate — survive verbatim so a battery
+    post-mortem can answer gate questions the snippet cap otherwise eats
+    (issue #114); prose-sized string values still clip."""
+    if not isinstance(response, str):
+        return None
+    try:
+        data = json.loads(response)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    for candidate in (data, data.get("output")):
+        if isinstance(candidate, dict):
+            diagnostics = candidate.get("diagnostics")
+            if isinstance(diagnostics, dict):
+                return {
+                    key: _snippet(value) if isinstance(value, str) else value
+                    for key, value in diagnostics.items()
+                }
+    return None
+
+
+def _seat_entry(name: str, node: Any) -> dict[str, Any]:
+    """One child-node trace entry: snippeted response plus the structured
+    envelope diagnostics when the node carries them."""
+    response = node.get("response") if isinstance(node, dict) else node
+    entry: dict[str, Any] = {"node": name, "response": _snippet(response)}
+    diagnostics = _diagnostics(response)
+    if diagnostics is not None:
+        entry["diagnostics"] = diagnostics
+    return entry
+
+
 def build_turn_trace(ensemble_name: str, result_dict: dict[str, Any]) -> dict[str, Any]:
     """Per-node introspection from the engine's execution result."""
     results = result_dict.get("results", {})
@@ -70,14 +106,7 @@ def build_turn_trace(ensemble_name: str, result_dict: dict[str, Any]) -> dict[st
             child = _child_results(response)
             if child is not None:
                 entry["seat"] = [
-                    {
-                        "node": child_name,
-                        "response": _snippet(
-                            child_node.get("response")
-                            if isinstance(child_node, dict)
-                            else child_node
-                        ),
-                    }
+                    _seat_entry(child_name, child_node)
                     for child_name, child_node in child.items()
                 ]
             nodes.append(entry)

--- a/tests/unit/web/serving/test_turn_trace_snippet.py
+++ b/tests/unit/web/serving/test_turn_trace_snippet.py
@@ -8,6 +8,8 @@ diagnosis sessions (two 2026-07-09 loop investigations dead-ended on the
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from llm_orc.web.serving.turn_trace import build_turn_trace
@@ -73,3 +75,22 @@ def test_seat_envelope_diagnostics_survive_the_snippet_cap() -> None:
     assert diagnostics["accept_reason"] == "tests did not pass"
     # prose-sized fields still clip — only the structure is exempt
     assert len(diagnostics["retry_input"]) <= 281
+
+
+def test_emit_never_propagates_a_trace_build_failure(tmp_path: Path) -> None:
+    """PR #116 review: 'tracing must never break the serve' — a hostile
+    child response (pathologically nested JSON raises RecursionError at
+    parse) must not kill the request path. emit degrades to a stub trace."""
+    import json
+
+    from llm_orc.web.serving.turn_trace import emit_turn_trace
+
+    hostile = "[" * 10050 + "]" * 10050
+    child_result = {"results": {"round": {"response": hostile}}}
+    result = {
+        "results": {"seat": {"status": "success", "response": json.dumps(child_result)}}
+    }
+
+    trace = emit_turn_trace("serving", result, tmp_path)
+
+    assert trace["ensemble"] == "serving"

--- a/tests/unit/web/serving/test_turn_trace_snippet.py
+++ b/tests/unit/web/serving/test_turn_trace_snippet.py
@@ -34,3 +34,42 @@ def test_unparseable_snippet_env_falls_back_to_the_default(
 ) -> None:
     monkeypatch.setenv("LLM_ORC_SERVE_TRACE_SNIPPET", "lots")
     assert len(_trace_response(5000)) == 281
+
+
+def test_seat_envelope_diagnostics_survive_the_snippet_cap() -> None:
+    """Issue #114: the accept verdict fields (accept, held_round,
+    tests_pass/adequate) are small and structured — the snippet cap must
+    not cost them. A battery post-mortem could not answer "did the held
+    round fire?" because the clip ate the envelope."""
+    import json
+
+    envelope = {
+        "output": {
+            "status": "success",
+            "primary": "def add(a, b): return a + b" + "\n# pad" * 200,
+            "diagnostics": {
+                "ensemble": "build-gated",
+                "accept": False,
+                "accept_reason": "tests did not pass",
+                "tests_pass": False,
+                "tests_adequate": True,
+                "held_round": True,
+                "retry_input": "x" * 5000,
+            },
+        }
+    }
+    child_result = {"results": {"round": {"response": json.dumps(envelope)}}}
+    result = {
+        "results": {"seat": {"status": "success", "response": json.dumps(child_result)}}
+    }
+
+    trace = build_turn_trace("serving", result)
+
+    seat_nodes = trace["nodes"][0]["seat"]
+    diagnostics = seat_nodes[0]["diagnostics"]
+    assert diagnostics["accept"] is False
+    assert diagnostics["held_round"] is True
+    assert diagnostics["tests_adequate"] is True
+    assert diagnostics["accept_reason"] == "tests did not pass"
+    # prose-sized fields still clip — only the structure is exempt
+    assert len(diagnostics["retry_input"]) <= 281

--- a/tests/unit/web/test_api_v1_chat_completions.py
+++ b/tests/unit/web/test_api_v1_chat_completions.py
@@ -1087,3 +1087,62 @@ class TestServingResolvesSessionIdentity:
         cold_identities = [i for i in registry._states if i.method == "cold_start"]
         assert len(cold_identities) == 2
         assert cold_identities[0] != cold_identities[1]
+
+
+class TestBlankUserContent:
+    """A blank latest user message silently slides the turn boundary back
+    to a stale task — the string-shaped twin of the #107 parts blocker
+    (PR #113 review's standing observation). Blank USER strings 422
+    honestly; other roles keep their wire-legal blanks."""
+
+    def test_blank_string_user_message_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client, _, _ = _build_client(monkeypatch)
+
+        for blank in ("", "   "):
+            response = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "primary",
+                    "messages": [
+                        {"role": "user", "content": "build todo.py"},
+                        {"role": "assistant", "content": "done"},
+                        {"role": "user", "content": blank},
+                    ],
+                },
+            )
+
+            assert response.status_code == 422, repr(blank)
+
+    def test_blank_tool_and_null_assistant_content_still_accepted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client, _, _ = _build_client(monkeypatch)
+
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "primary",
+                "messages": [
+                    {"role": "user", "content": "lint the repo"},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "c1",
+                                "type": "function",
+                                "function": {
+                                    "name": "bash",
+                                    "arguments": '{"command": "ruff check ."}',
+                                },
+                            }
+                        ],
+                    },
+                    {"role": "tool", "tool_call_id": "c1", "content": ""},
+                ],
+            },
+        )
+
+        assert response.status_code == 200

--- a/tests/unit/web/test_api_v1_chat_completions.py
+++ b/tests/unit/web/test_api_v1_chat_completions.py
@@ -1146,3 +1146,26 @@ class TestBlankUserContent:
         )
 
         assert response.status_code == 200
+
+    def test_null_content_user_message_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PR #116 review: content: null on a USER message is the third twin
+        of the turn-boundary slide (the boundary scan skips it exactly like
+        blank strings and textless parts) and OpenAI requires user content —
+        422. Assistant null (tool_calls turns) stays legal."""
+        client, _, _ = _build_client(monkeypatch)
+
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "primary",
+                "messages": [
+                    {"role": "user", "content": "build todo.py"},
+                    {"role": "assistant", "content": "done"},
+                    {"role": "user", "content": None},
+                ],
+            },
+        )
+
+        assert response.status_code == 422


### PR DESCRIPTION
## What

Three small deterministic items bundled ahead of the release, each backed by this session's evidence:

1. **Turn-trace envelope diagnostics (#114, the low-hanging half).** The 13-turn battery post-mortem could not answer 'did the held round fire?' — the snippet cap ate the seat envelope. The typed verdict fields (`accept`, `accept_reason`, `tests_pass`, `tests_adequate`, `held_round`) now ride each seat child trace entry verbatim; prose-sized values still clip. (Also rediscovered: `LLM_ORC_SERVE_TRACE_SNIPPET` already raises the cap for live diagnosis — noted on the issue. The issue's structured-extract ask is what this implements; deeper trace work, if any, stays on #114.)
2. **Blank string user messages 422.** The string-shaped twin of the #107 parts blocker, flagged as a standing observation in PR #113's review record: a whitespace-only/empty latest user message slid the turn boundary to a stale task and re-executed it. Same role-scoped honesty rationale; tool/assistant blanks and `content: null` stay wire-legal.
3. **Battery turn cap 600s → 780s.** The 13-turn run lost turn 2 to a client timeout while the seat was still inside its 720s two-round budget.

Deliberately NOT bundled: #110 and #106 (gate/dispatch behavior changes deserving their own arcs), #90.

## Review record

Independent adversarial reviewer (fresh context): **APPROVE** with two low findings and one note, verified by probe — (1) the trace build could RecursionError through to_thread into the request path on pathologically nested child JSON (net-new parse site; the never-break-the-serve guard covered OSError only); (2) content: null on a USER message was a third twin of the turn-boundary slide, reproduced end-to-end. Both fixed post-approval with the reviewer's probes pinned as tests; its propagation probe reports "survived" against the fixed code. (3, note kept as-is per the reviewer: the diagnostics dict is producer-bound — fixed scalar keys — so no size cap added.) Clean probes: hostile envelope shapes (list/str/None/int/nested/unicode/10k keys), wire-legal blanks preserved on system/assistant/tool, battery cap consistency, full suite green. The reviewer's confirmation round was cut short by a session usage limit; verification of the two fixes was completed by running its retained probe files directly.

## Evidence

TDD on 1 and 2 (each watched failing first; blank-tool-result acceptance pinned alongside the user rejection). Full suite 2826 passed, 91.77% coverage, strict hooks green.
